### PR TITLE
fix: slice tree-sitter byte offsets on bytes, not on the decoded string

### DIFF
--- a/golang_pipeline/generate_file_information.py
+++ b/golang_pipeline/generate_file_information.py
@@ -16,12 +16,14 @@ _MODULE_NAME_CACHE: Dict[str, Optional[str]] = {}
 def parse_file(filename: str):
     with open(filename, "r", encoding="utf-8") as f:
         code = f.read()
-    tree = parser.parse(code.encode("utf-8"))
+    code = code.encode("utf-8")
+    tree = parser.parse(code)
     return tree, code
 
 
-def _node_text(source: str, node) -> str:
-    return source[node.start_byte : node.end_byte]
+def _node_text(source: bytes, node) -> str:
+    # tree-sitter offsets are byte offsets, so slice the bytes and decode.
+    return source[node.start_byte : node.end_byte].decode("utf-8", "replace")
 
 
 def _strip_quotes(value: Optional[str]) -> str:

--- a/golang_pipeline/identify_api_functions.py
+++ b/golang_pipeline/identify_api_functions.py
@@ -33,8 +33,9 @@ class HandlerInfo:
     selector: Optional[str] = None
 
 
-def _node_text(source: str, node: Node) -> str:
-    return source[node.start_byte : node.end_byte]
+def _node_text(source: bytes, node: Node) -> str:
+    # tree-sitter offsets are byte offsets, so slice the bytes and decode.
+    return source[node.start_byte : node.end_byte].decode("utf-8", "replace")
 
 
 def _strip_quotes(value: Optional[str]) -> str:
@@ -329,11 +330,11 @@ def _is_call_operand_of_methods(call_node: Node, source: str) -> bool:
 
 def find_api_endpoints(file_path: Path, repo_root: str) -> List[Dict]:
     try:
-        source = file_path.read_text(encoding="utf-8")
+        source = file_path.read_bytes()
     except OSError:
         return []
 
-    tree = parser.parse(source.encode("utf-8"))
+    tree = parser.parse(source)
     functions_by_name = _collect_function_definitions(
         tree.root_node, source, file_path
     )

--- a/rails_pipeline/generate_file_information.py
+++ b/rails_pipeline/generate_file_information.py
@@ -15,12 +15,14 @@ parser = Parser(RUBY_LANGUAGE)
 def parse_file(filename: str):
     with open(filename, "r", encoding="utf-8") as f:
         code = f.read()
-    tree = parser.parse(code.encode("utf-8"))
+    code = code.encode("utf-8")
+    tree = parser.parse(code)
     return tree, code
 
 
-def _node_text(source: str, node) -> str:
-    return source[node.start_byte : node.end_byte]
+def _node_text(source: bytes, node) -> str:
+    # tree-sitter offsets are byte offsets, so slice the bytes and decode.
+    return source[node.start_byte : node.end_byte].decode("utf-8", "replace")
 
 
 def _gather_class_info(node, source: str) -> Dict:

--- a/rails_pipeline/identify_api_functions.py
+++ b/rails_pipeline/identify_api_functions.py
@@ -82,11 +82,11 @@ def _update_route_map(
     route_map: Dict[str, List[Dict]], routes_file: Path
 ) -> None:
     try:
-        source = routes_file.read_text(encoding="utf-8")
+        source = routes_file.read_bytes()
     except OSError:
         return
 
-    tree = parser.parse(source.encode("utf-8"))
+    tree = parser.parse(source)
     context = RouteContext()
     routes: List[Dict] = []
 
@@ -650,11 +650,11 @@ def _extract_controller_endpoints(
         return []
 
     try:
-        source = file_path.read_text(encoding="utf-8")
+        source = file_path.read_bytes()
     except OSError:
         return []
 
-    tree = parser.parse(source.encode("utf-8"))
+    tree = parser.parse(source)
     class_methods = _collect_controller_methods(tree.root_node, source, file_path)
 
     methods_by_name = {method["name"]: method for method in class_methods}
@@ -1044,5 +1044,6 @@ def _literal_text(node: Optional[Node], source: str) -> str:
     return text
 
 
-def _node_text(source: str, node: Node) -> str:
-    return source[node.start_byte : node.end_byte]
+def _node_text(source: bytes, node: Node) -> str:
+    # tree-sitter offsets are byte offsets, so slice the bytes and decode.
+    return source[node.start_byte : node.end_byte].decode("utf-8", "replace")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_tree_sitter_byte_offsets.py
+++ b/tests/test_tree_sitter_byte_offsets.py
@@ -1,0 +1,115 @@
+"""Regression tests for byte offsets vs string offsets.
+
+tree-sitter is fed UTF-8 bytes and reports node offsets in bytes. Slicing those
+offsets into a decoded str is only correct while every character is ASCII. One
+non-ASCII character (an em dash in a comment, a smart quote, an accented name,
+an emoji) shifts every later offset and the extractors start reading garbage,
+so routes are silently dropped.
+
+These tests put a single non-ASCII character in a comment on line 1 and then
+assert every route below it is still found.
+"""
+
+from pathlib import Path
+
+from golang_pipeline.identify_api_functions import find_api_endpoints as go_find_api_endpoints
+from rails_pipeline.identify_api_functions import find_api_endpoints as rails_find_api_endpoints
+
+# U+2014 EM DASH: one character, three bytes in UTF-8.
+EM_DASH = "—"
+
+GO_SOURCE_TEMPLATE = """package main
+
+// Routes are grouped by resource {sep} see docs/routing.md for the conventions.
+
+import "github.com/gin-gonic/gin"
+
+func listUsers(c *gin.Context) {{}}
+
+func createUser(c *gin.Context) {{}}
+
+func deleteUser(c *gin.Context) {{}}
+
+func RegisterRoutes(r *gin.Engine) {{
+	r.GET("/users", listUsers)
+	r.POST("/users", createUser)
+	r.DELETE("/users/:id", deleteUser)
+}}
+"""
+
+EXPECTED_GO_ROUTES = {
+    ("GET", "/users"),
+    ("POST", "/users"),
+    ("DELETE", "/users/:id"),
+}
+
+RAILS_ROUTES_TEMPLATE = """# API routes {sep} keep them alphabetical.
+Rails.application.routes.draw do
+  get "/health", to: "health#show"
+  post "/users", to: "users#create"
+end
+"""
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _go_routes(tmp_path: Path, separator: str) -> set:
+    source = GO_SOURCE_TEMPLATE.format(sep=separator)
+    go_file = _write(tmp_path / "routes.go", source)
+    endpoints = go_find_api_endpoints(go_file, str(tmp_path))
+    return {(endpoint["http_method"], endpoint["route"]) for endpoint in endpoints}
+
+
+def test_go_routes_found_with_ascii_comment(tmp_path):
+    """Baseline: an all-ASCII file has always worked."""
+    assert _go_routes(tmp_path, "-") == EXPECTED_GO_ROUTES
+
+
+def test_go_routes_found_after_non_ascii_comment(tmp_path):
+    """One em dash above the routes must not hide them.
+
+    Before the byte-offset fix this returned an empty set: the three-byte em
+    dash pushed every later str index two positions out of alignment, so the
+    method and path literals were read as garbage and every route was dropped.
+    """
+    assert _go_routes(tmp_path, EM_DASH) == EXPECTED_GO_ROUTES
+
+
+def test_go_handler_names_survive_non_ascii(tmp_path):
+    """Handler names come from the same offsets, so check them too."""
+    source = GO_SOURCE_TEMPLATE.format(sep=EM_DASH)
+    go_file = _write(tmp_path / "routes.go", source)
+    endpoints = go_find_api_endpoints(go_file, str(tmp_path))
+    handlers = {endpoint["handler_name"] for endpoint in endpoints}
+    assert handlers == {"listUsers", "createUser", "deleteUser"}
+
+
+def _rails_route_map(tmp_path: Path, separator: str) -> dict:
+    routes_file = _write(
+        tmp_path / "config" / "routes.rb",
+        RAILS_ROUTES_TEMPLATE.format(sep=separator),
+    )
+    route_map: dict = {}
+    rails_find_api_endpoints(routes_file, str(tmp_path), route_map)
+    return {
+        controller: {(route["verb"], route["path"], route["action"]) for route in routes}
+        for controller, routes in route_map.items()
+    }
+
+
+EXPECTED_RAILS_ROUTES = {
+    "health": {("GET", "/health", "show")},
+    "users": {("POST", "/users", "create")},
+}
+
+
+def test_rails_routes_found_with_ascii_comment(tmp_path):
+    assert _rails_route_map(tmp_path, "-") == EXPECTED_RAILS_ROUTES
+
+
+def test_rails_routes_found_after_non_ascii_comment(tmp_path):
+    assert _rails_route_map(tmp_path, EM_DASH) == EXPECTED_RAILS_ROUTES


### PR DESCRIPTION
## What breaks

tree-sitter is fed the file as UTF-8 **bytes** and reports every node position as a **byte** offset (`node.start_byte`, `node.end_byte`). The Go and Rails pipelines took those byte offsets and sliced them into the **decoded string**:

```python
def _node_text(source: str, node) -> str:
    return source[node.start_byte : node.end_byte]   # source is a str
```

Bytes and characters only line up while the file is pure ASCII. The moment one non-ASCII character appears (an em dash in a comment, a smart quote, an accented name, an emoji), every offset after it points at the wrong place in the string, and the extractor reads shifted garbage instead of the route literal. It does not raise; the route just silently vanishes.

## What it cost

A customer Go repo. `backend/src/factors/handler/routes.go` registers **754** gin routes and contains a single em dash, in a comment, on line 57:

```go
// Scout Schedule Run Now API — private-token (API key) auth. Tight rate li...
```

Everything after that line was misread. `"POST"` came back as `'ST("'`, `"GET"` as `'e/l'`. The verb no longer matched, so the registration was dropped.

| | routes recognised in routes.go | endpoints in the whole scan |
|---|---|---|
| before | 5 of 754 | **6** |
| after | 754 of 754 | **372** |

One comment character cost 749 route registrations. That repo has 113 Go files carrying at least one non-ASCII byte, so this was not a one-file accident, and it has been silently wrong since the Go pipeline landed on 2026-06-03.

## The fix

Slice the bytes, then decode the slice. This is the pattern the Node pipeline has always used (`nodejs_pipeline/identify_api_functions.py`), so this brings Go and Rails in line with what is already in the repo:

```python
def _node_text(source: bytes, node) -> str:
    return source[node.start_byte : node.end_byte].decode("utf-8", "replace")
```

Sites changed (source is now read as bytes and handed to the parser directly, so the buffer being sliced is the same buffer tree-sitter measured):

- `golang_pipeline/identify_api_functions.py`: `_node_text`, and `find_api_endpoints` now reads bytes.
- `golang_pipeline/generate_file_information.py`: `_node_text` and `parse_file`.
- `rails_pipeline/identify_api_functions.py`: `_node_text`, plus both read sites (`config/routes.rb` and controller files).
- `rails_pipeline/generate_file_information.py`: `_node_text` and `parse_file`.

I grepped the repo for every other `start_byte` use. The only remaining one is the Node pipeline, which was already correct. Everything else reads node text through `node.text.decode(...)`, which tree-sitter itself gets right.

Decoding with `errors="replace"` closes a crash path too: `read_text` raises `UnicodeDecodeError` on a non-UTF-8 source file, and `UnicodeDecodeError` is not an `OSError`, so it slipped past the existing `except OSError` and took the scan down.

## Tests

The repo had no test layer, so this adds a minimal pytest one: `tests/conftest.py` (puts the repo root on `sys.path`) and `tests/test_tree_sitter_byte_offsets.py`.

Each test puts one em dash in a comment above the routes and asserts every route below it is still extracted, with an all-ASCII baseline next to it so a failure tells you the non-ASCII character is the variable.

Against this branch:

```
tests/test_tree_sitter_byte_offsets.py::test_go_routes_found_with_ascii_comment PASSED
tests/test_tree_sitter_byte_offsets.py::test_go_routes_found_after_non_ascii_comment PASSED
tests/test_tree_sitter_byte_offsets.py::test_go_handler_names_survive_non_ascii PASSED
tests/test_tree_sitter_byte_offsets.py::test_rails_routes_found_with_ascii_comment PASSED
tests/test_tree_sitter_byte_offsets.py::test_rails_routes_found_after_non_ascii_comment PASSED

5 passed in 0.62s
```

Against `main` (fix reverted, tests kept), which is the check that matters:

```
FAILED tests/test_tree_sitter_byte_offsets.py::test_go_routes_found_after_non_ascii_comment
FAILED tests/test_tree_sitter_byte_offsets.py::test_go_handler_names_survive_non_ascii
FAILED tests/test_tree_sitter_byte_offsets.py::test_rails_routes_found_after_non_ascii_comment
3 failed, 2 passed in 0.04s
```

The two that pass are the ASCII baselines, exactly as expected.

Run them with:

```bash
pip install -r requirements.txt pytest
pytest tests/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
