### PR TITLE
Follow-ups: Rails concern support with correct Ruby ancestry, zero-spend empty runs, dependency cleanup

### DIFF
--- a/bootstrap_mcp_runner.sh
+++ b/bootstrap_mcp_runner.sh
@@ -102,7 +102,6 @@ pip3 install \
   "tree-sitter-ruby==0.23.1" \
   "tree-sitter-go==0.25.0" \
   "tree-sitter-typescript==0.23.2" \
-  "esprima==4.0.1" \
   "requests"
 
 # --- repo setup (clone/update specific branch) ---

--- a/rails_pipeline/generate_file_information.py
+++ b/rails_pipeline/generate_file_information.py
@@ -27,6 +27,33 @@ def _node_text(source: bytes, node) -> str:
     return source[node.start_byte : node.end_byte].decode("utf-8", "replace")
 
 
+def _gather_included_modules(node, source: str) -> List[str]:
+    """
+    The modules a class body includes. Ruby looks a method up in the included
+    modules before the superclass, so an action can live in a concern; only the
+    class's own body counts, never a nested class's.
+    """
+    body_node = node.child_by_field_name("body")
+    if body_node is None:
+        return []
+
+    names: List[str] = []
+    for child in body_node.children:
+        if child.type not in {"call", "command", "command_call"}:
+            continue
+        method_node = child.child_by_field_name("method")
+        if method_node is None or _node_text(source, method_node).strip() != "include":
+            continue
+        arguments_node = child.child_by_field_name("arguments")
+        if arguments_node is None:
+            continue
+        # `include Trackable, Auditable` includes both.
+        for argument in arguments_node.children:
+            if argument.type in {"constant", "scope_resolution"}:
+                names.append(_node_text(source, argument).strip())
+    return names
+
+
 def _gather_class_info(node, source: str) -> Dict:
     name_node = node.child_by_field_name("name")
     name = _node_text(source, name_node) if name_node else "<anonymous>"
@@ -42,6 +69,7 @@ def _gather_class_info(node, source: str) -> Dict:
         "start_line": node.start_point[0] + 1,
         "end_line": node.end_point[0] + 1,
         "superclass": superclass,
+        "includes": _gather_included_modules(node, source),
     }
 
 
@@ -183,9 +211,12 @@ def get_elements(tree, source: str, base_directory: str) -> Dict:
     while cursor:
         node = cursor.pop()
         node_type = node.type
-        if node_type == "class":
+        # The `class` and `module` keywords are tokens of the same type as the
+        # definition they open, so an unnamed match is the bare keyword and
+        # collecting it yielded a phantom anonymous entry per real definition.
+        if node_type == "class" and node.is_named:
             elements["classes"].append(_gather_class_info(node, source))
-        elif node_type == "module":
+        elif node_type == "module" and node.is_named:
             elements["modules"].append(_gather_module_info(node, source))
         elif node_type in {"method", "singleton_method"}:
             elements["functions"].append(_gather_method_info(node, source))

--- a/rails_pipeline/generate_file_information.py
+++ b/rails_pipeline/generate_file_information.py
@@ -27,17 +27,20 @@ def _node_text(source: bytes, node) -> str:
     return source[node.start_byte : node.end_byte].decode("utf-8", "replace")
 
 
-def _gather_included_modules(node, source: str) -> List[str]:
+def _gather_included_modules(node, source: str) -> List[List[str]]:
     """
-    The modules a class body includes. Ruby looks a method up in the included
-    modules before the superclass, so an action can live in a concern; only the
-    class's own body counts, never a nested class's.
+    The modules a class or module body includes, one group per include
+    statement and in source order. Ruby looks a method up in the included
+    modules before the superclass, so an action can live in a concern, and the
+    ancestor order it builds depends on both which statement an argument came
+    from and where it sat in that statement; a flat list loses both. Only the
+    body's own statements count, never a nested class's.
     """
     body_node = node.child_by_field_name("body")
     if body_node is None:
         return []
 
-    names: List[str] = []
+    groups: List[List[str]] = []
     for child in body_node.children:
         if child.type not in {"call", "command", "command_call"}:
             continue
@@ -47,11 +50,15 @@ def _gather_included_modules(node, source: str) -> List[str]:
         arguments_node = child.child_by_field_name("arguments")
         if arguments_node is None:
             continue
-        # `include Trackable, Auditable` includes both.
-        for argument in arguments_node.children:
-            if argument.type in {"constant", "scope_resolution"}:
-                names.append(_node_text(source, argument).strip())
-    return names
+        # `include Trackable, Auditable` includes both, Trackable first.
+        names = [
+            _node_text(source, argument).strip()
+            for argument in arguments_node.children
+            if argument.type in {"constant", "scope_resolution"}
+        ]
+        if names:
+            groups.append(names)
+    return groups
 
 
 def _gather_class_info(node, source: str) -> Dict:
@@ -81,6 +88,9 @@ def _gather_module_info(node, source: str) -> Dict:
         "name": name,
         "start_line": node.start_point[0] + 1,
         "end_line": node.end_point[0] + 1,
+        # A concern includes concerns of its own, and those sit in the ancestry
+        # of every class that includes it.
+        "includes": _gather_included_modules(node, source),
     }
 
 

--- a/rails_pipeline/identify_api_functions.py
+++ b/rails_pipeline/identify_api_functions.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from tree_sitter import Language, Node, Parser
 import tree_sitter_ruby
@@ -111,17 +111,71 @@ def find_api_endpoints(
     route_map: Dict[str, List[Dict]],
     class_index: Optional[Dict[str, Dict]] = None,
     dropped_routes: Optional[List[str]] = None,
+    concerns: Optional[Dict[str, Tuple[Node, bytes]]] = None,
 ) -> List[Dict]:
     if is_route_file(file_path):
-        _update_route_map(route_map, file_path)
+        _update_route_map(route_map, file_path, concerns)
         return []
     return _extract_controller_endpoints(
         file_path, repo_root, route_map, class_index, dropped_routes
     )
 
 
+def collect_route_concerns(
+    route_files: Iterable[Path],
+) -> Dict[str, Tuple[Node, bytes]]:
+    """
+    Every `concern :name do ... end` the route files define, each kept with the
+    buffer it was parsed from. config/routes.rb defines concerns that
+    config/routes/admin.rb references, so the table has to be complete before
+    the first file is walked, and a concern replayed in another route file has
+    to walk its own bytes: tree-sitter offsets only mean anything against the
+    buffer they were taken from.
+    """
+    concerns: Dict[str, Tuple[Node, bytes]] = {}
+    for routes_file in route_files:
+        try:
+            source = Path(routes_file).read_bytes()
+        except OSError:
+            continue
+        _collect_concern_definitions(parser.parse(source).root_node, source, concerns)
+    return concerns
+
+
+def _collect_concern_definitions(
+    node: Node, source: bytes, concerns: Dict[str, Tuple[Node, bytes]]
+) -> None:
+    call_node = node
+    block_node: Optional[Node] = None
+    if node.type == "method_add_block":
+        call_node = node.child_by_field_name("call")
+        block_node = node.child_by_field_name("block")
+    elif node.type in {"call", "command", "command_call"}:
+        for child in node.children:
+            if child.type == "do_block":
+                block_node = child
+                break
+
+    if call_node is not None and block_node is not None:
+        method_node = call_node.child_by_field_name("method")
+        if (
+            method_node is not None
+            and _node_text(source, method_node).strip().lower() == "concern"
+        ):
+            concern_name = _first_symbol_or_string(
+                _extract_arguments(call_node, source)
+            )
+            if concern_name:
+                concerns.setdefault(concern_name, (block_node, source))
+
+    for child in node.children:
+        _collect_concern_definitions(child, source, concerns)
+
+
 def _update_route_map(
-    route_map: Dict[str, List[Dict]], routes_file: Path
+    route_map: Dict[str, List[Dict]],
+    routes_file: Path,
+    shared_concerns: Optional[Dict[str, Tuple[Node, bytes]]] = None,
 ) -> None:
     try:
         source = routes_file.read_bytes()
@@ -131,7 +185,9 @@ def _update_route_map(
     tree = parser.parse(source)
     context = RouteContext()
     routes: List[Dict] = []
-    concerns: Dict[str, Node] = {}
+    # A copy: what this file defines is replayed from this file's buffer and
+    # must not leak into the table the other route files walk.
+    concerns: Dict[str, Tuple[Node, bytes]] = dict(shared_concerns or {})
 
     _walk_routes(tree.root_node, source, context, routes, concerns)
 
@@ -151,7 +207,7 @@ def _walk_routes(
     source: str,
     context: RouteContext,
     routes: List[Dict],
-    concerns: Dict[str, Node],
+    concerns: Dict[str, Tuple[Node, bytes]],
 ):
     if node.type == "call":
         block_node: Optional[Node] = None
@@ -183,7 +239,7 @@ def _handle_command(
     source: str,
     context: RouteContext,
     routes: List[Dict],
-    concerns: Dict[str, Node],
+    concerns: Dict[str, Tuple[Node, bytes]],
 ):
     method_node = call_node.child_by_field_name("method")
     if not method_node:
@@ -199,7 +255,7 @@ def _handle_command(
         # site: they are replayed inside every resource that asks for it.
         concern_name = _first_symbol_or_string(args)
         if concern_name and block_node is not None:
-            concerns[concern_name] = block_node
+            concerns[concern_name] = (block_node, source)
         return
 
     if method_lower == "namespace":
@@ -361,21 +417,26 @@ def _replay_concerns(
     controller_key: str,
     routes: List[Dict],
     plural: bool,
-    concerns: Dict[str, Node],
+    concerns: Dict[str, Tuple[Node, bytes]],
     shallow: bool,
 ):
     """
     Emit the routes of every named concern inside the resource asking for it,
     which is where Rails puts them. Reached from both spellings: the
     `concerns: :commentable` option and the `concerns :commentable` call.
+
+    The concern is walked against the buffer it was defined in, never the one
+    referencing it: the referencing file's bytes would read the nodes at the
+    wrong offsets.
     """
     for concern_name in concern_names:
-        concern_block = concerns.get(concern_name)
-        if concern_block is None:
+        concern_entry = concerns.get(concern_name)
+        if concern_entry is None:
             continue
+        concern_block, concern_source = concern_entry
         _walk_resource_block(
             concern_block,
-            source,
+            concern_source,
             context,
             controller_key,
             routes,
@@ -403,7 +464,7 @@ def _walk_resource_block(
     controller_key: str,
     routes: List[Dict],
     plural: bool,
-    concerns: Dict[str, Node],
+    concerns: Dict[str, Tuple[Node, bytes]],
     shallow: bool = False,
 ):
     for child in _iter_block_children(block_node):
@@ -839,9 +900,10 @@ def _inherited_method_info(
     file_path: Path,
 ) -> Optional[Dict]:
     """
-    The action as a parent controller defines it. Walks the ancestor chain the
-    class index tracks and returns the first parent that carries the method, so
-    the parent's own body is what gets documented.
+    The action as an ancestor of the controller defines it. Walks the ancestors
+    the class index tracks, in the order Ruby resolves a method in, and returns
+    the first one that carries the method, so the ancestor's own body is what
+    gets documented.
     """
     if not class_index or not class_name:
         return None
@@ -849,6 +911,19 @@ def _inherited_method_info(
     entry = class_index.get(class_name)
     visited = set()
     while entry:
+        # An included module wins over the superclass, and a later include wins
+        # over an earlier one, which is the ancestry Ruby builds. A module the
+        # scan never saw resolves to nothing and changes nothing.
+        for module_name in reversed(entry.get("includes") or []):
+            module_entry = class_index.get(module_name)
+            if not module_entry:
+                continue
+            found = _ancestor_method_info(
+                module_entry, module_name, action, class_name
+            )
+            if found:
+                return found
+
         superclass = entry.get("superclass")
         if not superclass or superclass in visited:
             return None
@@ -856,20 +931,30 @@ def _inherited_method_info(
         parent = class_index.get(superclass)
         if not parent:
             return None
-        meta = (parent.get("methods") or {}).get(action)
-        parent_file = parent.get("file_path")
-        if meta and parent_file and isinstance(meta.get("start_line"), int):
-            return {
-                "type": "method",
-                "name": action,
-                "start_line": meta["start_line"],
-                "end_line": meta["end_line"],
-                "file_path": str(parent_file),
-                "class_name": class_name,
-                "inherited_from": superclass,
-            }
+        found = _ancestor_method_info(parent, superclass, action, class_name)
+        if found:
+            return found
         entry = parent
     return None
+
+
+def _ancestor_method_info(
+    entry: Dict, ancestor_name: str, action: str, class_name: str
+) -> Optional[Dict]:
+    """The action as one ancestor defines it, or None when it does not."""
+    meta = (entry.get("methods") or {}).get(action)
+    ancestor_file = entry.get("file_path")
+    if not meta or not ancestor_file or not isinstance(meta.get("start_line"), int):
+        return None
+    return {
+        "type": "method",
+        "name": action,
+        "start_line": meta["start_line"],
+        "end_line": meta["end_line"],
+        "file_path": str(ancestor_file),
+        "class_name": class_name,
+        "inherited_from": ancestor_name,
+    }
 
 
 def _collect_controller_methods(root: Node, source: str, file_path: Path):

--- a/rails_pipeline/identify_api_functions.py
+++ b/rails_pipeline/identify_api_functions.py
@@ -905,37 +905,61 @@ def _inherited_method_info(
     the first one that carries the method, so the ancestor's own body is what
     gets documented.
     """
-    if not class_index or not class_name:
-        return None
+    for ancestor_name, entry in ancestor_chain(class_index, class_name):
+        found = _ancestor_method_info(entry, ancestor_name, action, class_name)
+        if found:
+            return found
+    return None
 
-    entry = class_index.get(class_name)
-    visited = set()
-    while entry:
-        # An included module wins over the superclass, and a later include wins
-        # over an earlier one, which is the ancestry Ruby builds. A module the
-        # scan never saw resolves to nothing and changes nothing.
-        for module_name in reversed(entry.get("includes") or []):
+
+def ancestor_chain(
+    class_index: Optional[Dict[str, Dict]], class_name: Optional[str]
+) -> List[Tuple[str, Dict]]:
+    """
+    The ancestors of a class, nearest first and without the class itself, in the
+    order Ruby resolves a method through them.
+
+    Ruby puts every module a body includes ahead of the superclass, a later
+    include statement ahead of an earlier one, and the arguments of a single
+    statement in the order they are written. A module that an included module
+    includes sits directly behind its includer. A name the scan never saw has
+    no entry to walk, so it drops out of the chain and changes nothing.
+    """
+    chain: List[Tuple[str, Dict]] = []
+    if not class_index or not class_name:
+        return chain
+
+    seen = set()
+    current = class_name
+    while current and current not in seen:
+        seen.add(current)
+        entry = class_index.get(current)
+        if not entry:
+            break
+        if current != class_name:
+            chain.append((current, entry))
+        _extend_with_included_modules(class_index, entry, seen, chain)
+        current = entry.get("superclass")
+    return chain
+
+
+def _extend_with_included_modules(
+    class_index: Dict[str, Dict],
+    entry: Dict,
+    seen: set,
+    chain: List[Tuple[str, Dict]],
+) -> None:
+    """The includes of one body, linearized behind it."""
+    for group in reversed(entry.get("includes") or []):
+        for module_name in group:
+            if not module_name or module_name in seen:
+                continue
+            seen.add(module_name)
             module_entry = class_index.get(module_name)
             if not module_entry:
                 continue
-            found = _ancestor_method_info(
-                module_entry, module_name, action, class_name
-            )
-            if found:
-                return found
-
-        superclass = entry.get("superclass")
-        if not superclass or superclass in visited:
-            return None
-        visited.add(superclass)
-        parent = class_index.get(superclass)
-        if not parent:
-            return None
-        found = _ancestor_method_info(parent, superclass, action, class_name)
-        if found:
-            return found
-        entry = parent
-    return None
+            chain.append((module_name, module_entry))
+            _extend_with_included_modules(class_index, module_entry, seen, chain)
 
 
 def _ancestor_method_info(

--- a/rails_pipeline/run_swagger_generation.py
+++ b/rails_pipeline/run_swagger_generation.py
@@ -29,6 +29,7 @@ from rails_pipeline.find_api_definition_files import (
     find_api_definition_files,
 )
 from rails_pipeline.identify_api_functions import (
+    ancestor_chain,
     collect_route_concerns,
     find_api_endpoints,
     is_route_file,
@@ -84,7 +85,7 @@ METADATA_CACHE_PIPELINE = "rails"
 
 # Bumped when the shape of a metadata entry changes. A missing or stale marker
 # wipes this pipeline's cache before anything reads it.
-METADATA_CACHE_VERSION = "2"
+METADATA_CACHE_VERSION = "3"
 
 # File path -> content hash, and file path -> the cache entry holding its
 # metadata. Both are per run: two runs in one process are two checkouts.
@@ -252,32 +253,14 @@ def _ancestor_definition_imports(class_name: Optional[str], route) -> List[Dict]
     parent leaves the child's endpoint looking untouched and it is never
     regenerated. Read off whatever class index the run built; without one there
     are no ancestors to record and the endpoint is dirtied by its own file
-    alone.
+    alone. The same linearization the action resolution walks, so every file
+    that could hold the action is an edge.
     """
     imports: List[Dict] = []
-    entry = _CLASS_INDEX_CACHE.get(class_name) if class_name else None
-    visited = set()
-    while entry:
-        for module_name in entry.get("includes") or []:
-            module_entry = _CLASS_INDEX_CACHE.get(module_name)
-            if not module_entry or module_name in visited:
-                continue
-            visited.add(module_name)
-            module_import = _ancestor_import_entry(module_entry, module_name, route)
-            if module_import:
-                imports.append(module_import)
-
-        superclass = entry.get("superclass")
-        if not superclass or superclass in visited:
-            break
-        visited.add(superclass)
-        parent = _CLASS_INDEX_CACHE.get(superclass)
-        if not parent:
-            break
-        parent_import = _ancestor_import_entry(parent, superclass, route)
-        if parent_import:
-            imports.append(parent_import)
-        entry = parent
+    for ancestor_name, entry in ancestor_chain(_CLASS_INDEX_CACHE, class_name):
+        ancestor_import = _ancestor_import_entry(entry, ancestor_name, route)
+        if ancestor_import:
+            imports.append(ancestor_import)
     return imports
 
 
@@ -952,6 +935,9 @@ def _ensure_class_index(directory_path: str) -> Dict[str, Dict[str, object]]:
         classes = elements.get("classes", [])
         modules = elements.get("modules", [])
         functions = elements.get("functions", [])
+        # Every class and module the file defines, so a method can be handed to
+        # the nearest one that encloses it rather than to all of them.
+        definition_ranges = _definition_ranges(classes, modules)
 
         for klass in classes:
             name = klass.get("name")
@@ -965,7 +951,10 @@ def _ensure_class_index(directory_path: str) -> Dict[str, Dict[str, object]]:
                 "start_line": klass.get("start_line"),
                 "end_line": klass.get("end_line"),
                 "methods": _contained_method_map(
-                    functions, klass.get("start_line"), klass.get("end_line")
+                    functions,
+                    klass.get("start_line"),
+                    klass.get("end_line"),
+                    definition_ranges,
                 ),
             }
 
@@ -979,11 +968,14 @@ def _ensure_class_index(directory_path: str) -> Dict[str, Dict[str, object]]:
                 "type": "module",
                 "file_path": source_file,
                 "superclass": None,
-                "includes": [],
+                "includes": module.get("includes") or [],
                 "start_line": module.get("start_line"),
                 "end_line": module.get("end_line"),
                 "methods": _contained_method_map(
-                    functions, module.get("start_line"), module.get("end_line")
+                    functions,
+                    module.get("start_line"),
+                    module.get("end_line"),
+                    definition_ranges,
                 ),
             }
 
@@ -1008,8 +1000,47 @@ def _ensure_class_index(directory_path: str) -> Dict[str, Dict[str, object]]:
     return _CLASS_INDEX_CACHE
 
 
-def _contained_method_map(functions: List[Dict], start_line, end_line) -> Dict[str, Dict[str, int]]:
-    """The methods a class or module body holds, by name."""
+def _definition_ranges(classes: List[Dict], modules: List[Dict]) -> List[Tuple[int, int]]:
+    """The line span of every class and module one file defines."""
+    ranges: List[Tuple[int, int]] = []
+    for item in list(classes) + list(modules):
+        start_line = item.get("start_line")
+        end_line = item.get("end_line")
+        if isinstance(start_line, int) and isinstance(end_line, int):
+            ranges.append((start_line, end_line))
+    return ranges
+
+
+def _nearest_definition(
+    line: int, definition_ranges: List[Tuple[int, int]]
+) -> Optional[Tuple[int, int]]:
+    """The innermost class or module whose span holds this line."""
+    nearest: Optional[Tuple[int, int]] = None
+    for candidate in definition_ranges:
+        if not candidate[0] <= line <= candidate[1]:
+            continue
+        if (
+            nearest is None
+            or candidate[0] > nearest[0]
+            or (candidate[0] == nearest[0] and candidate[1] < nearest[1])
+        ):
+            nearest = candidate
+    return nearest
+
+
+def _contained_method_map(
+    functions: List[Dict],
+    start_line,
+    end_line,
+    definition_ranges: List[Tuple[int, int]],
+) -> Dict[str, Dict[str, int]]:
+    """The methods a class or module body owns, by name.
+
+    A method belongs to the nearest definition that encloses it and to nothing
+    else. Taking every `def` inside the span handed a concern the methods of its
+    own nested `module ClassMethods`, and a route named after one of them was
+    documented as an action Rails answers 404 on.
+    """
     method_map: Dict[str, Dict[str, int]] = {}
     if not isinstance(start_line, int) or not isinstance(end_line, int):
         return method_map
@@ -1018,15 +1049,18 @@ def _contained_method_map(functions: List[Dict], start_line, end_line) -> Dict[s
         func_start = func.get("start_line")
         func_end = func.get("end_line")
         if (
-            method_name
-            and isinstance(func_start, int)
-            and isinstance(func_end, int)
-            and start_line <= func_start <= end_line
+            not method_name
+            or not isinstance(func_start, int)
+            or not isinstance(func_end, int)
+            or not start_line <= func_start <= end_line
         ):
-            method_map[method_name] = {
-                "start_line": func_start,
-                "end_line": func_end,
-            }
+            continue
+        if _nearest_definition(func_start, definition_ranges) != (start_line, end_line):
+            continue
+        method_map[method_name] = {
+            "start_line": func_start,
+            "end_line": func_end,
+        }
     return method_map
 
 

--- a/rails_pipeline/run_swagger_generation.py
+++ b/rails_pipeline/run_swagger_generation.py
@@ -29,6 +29,7 @@ from rails_pipeline.find_api_definition_files import (
     find_api_definition_files,
 )
 from rails_pipeline.identify_api_functions import (
+    collect_route_concerns,
     find_api_endpoints,
     is_route_file,
 )
@@ -83,7 +84,7 @@ METADATA_CACHE_PIPELINE = "rails"
 
 # Bumped when the shape of a metadata entry changes. A missing or stale marker
 # wipes this pipeline's cache before anything reads it.
-METADATA_CACHE_VERSION = "1"
+METADATA_CACHE_VERSION = "2"
 
 # File path -> content hash, and file path -> the cache entry holding its
 # metadata. Both are per run: two runs in one process are two checkouts.
@@ -227,8 +228,61 @@ def _resolve_imported_definitions(import_item, route):
     return candidates
 
 
+def _ancestor_import_entry(entry: Dict, name: str, route) -> Optional[Dict]:
+    file_path = entry.get("file_path")
+    start_line = entry.get("start_line")
+    end_line = entry.get("end_line")
+    if not file_path or not isinstance(start_line, int) or not isinstance(end_line, int):
+        return None
+    return {
+        "type": entry.get("type") or "class",
+        "name": name,
+        "start_line": start_line,
+        "end_line": end_line,
+        "route": route,
+        "file_path": os.path.abspath(str(file_path)),
+    }
+
+
+def _ancestor_definition_imports(class_name: Optional[str], route) -> List[Dict]:
+    """The dependency edges to the files an action's controller descends from.
+
+    Ruby binds no name on require, so a parent controller and a concern are
+    dependencies no require based edge ever records: without them, editing the
+    parent leaves the child's endpoint looking untouched and it is never
+    regenerated. Read off whatever class index the run built; without one there
+    are no ancestors to record and the endpoint is dirtied by its own file
+    alone.
+    """
+    imports: List[Dict] = []
+    entry = _CLASS_INDEX_CACHE.get(class_name) if class_name else None
+    visited = set()
+    while entry:
+        for module_name in entry.get("includes") or []:
+            module_entry = _CLASS_INDEX_CACHE.get(module_name)
+            if not module_entry or module_name in visited:
+                continue
+            visited.add(module_name)
+            module_import = _ancestor_import_entry(module_entry, module_name, route)
+            if module_import:
+                imports.append(module_import)
+
+        superclass = entry.get("superclass")
+        if not superclass or superclass in visited:
+            break
+        visited.add(superclass)
+        parent = _CLASS_INDEX_CACHE.get(superclass)
+        if not parent:
+            break
+        parent_import = _ancestor_import_entry(parent, superclass, route)
+        if parent_import:
+            imports.append(parent_import)
+        entry = parent
+    return imports
+
+
 def _endpoint_imports(endpoint, abs_file_path, route):
-    return pipeline_common.endpoint_imports(
+    imports = pipeline_common.endpoint_imports(
         endpoint,
         abs_file_path,
         route,
@@ -236,6 +290,8 @@ def _endpoint_imports(endpoint, abs_file_path, route):
         get_dependencies,
         _resolve_imported_definitions,
     )
+    imports.extend(_ancestor_definition_imports(endpoint.get("class_name"), route))
+    return imports
 
 
 def _build_api_index(endpoints: list) -> dict:
@@ -704,14 +760,24 @@ def run_swagger_generation(host: str) -> Optional[Dict]:
         all_endpoints_dict: Dict[str, List[Dict]] = {}
         route_map: Dict[str, List[Dict]] = {}
         controller_files: List[Path] = []
+        route_files: List[Path] = []
         dropped_routes: List[str] = []
 
         for file in api_definition_files:
             ruby_file = Path(file)
             if is_route_file(ruby_file):
-                find_api_endpoints(ruby_file, directory_path, route_map)
+                route_files.append(ruby_file)
             else:
                 controller_files.append(ruby_file)
+
+        # Read off every route file before the first one is walked: a concern
+        # config/routes.rb defines is referenced from config/routes/admin.rb,
+        # and either file can be the one reached first.
+        route_concerns = collect_route_concerns(route_files)
+        for route_file in route_files:
+            find_api_endpoints(
+                route_file, directory_path, route_map, concerns=route_concerns
+            )
 
         for controller_file in controller_files:
             endpoints = find_api_endpoints(
@@ -884,36 +950,41 @@ def _ensure_class_index(directory_path: str) -> Dict[str, Dict[str, object]]:
 
         elements = data.get("elements", {})
         classes = elements.get("classes", [])
+        modules = elements.get("modules", [])
         functions = elements.get("functions", [])
 
         for klass in classes:
             name = klass.get("name")
             if not name or name in _CLASS_INDEX_CACHE:
                 continue
-            class_start = klass.get("start_line")
-            class_end = klass.get("end_line")
-            method_map: Dict[str, Dict[str, int]] = {}
-            if isinstance(class_start, int) and isinstance(class_end, int):
-                for func in functions:
-                    method_name = func.get("name")
-                    start_line = func.get("start_line")
-                    end_line = func.get("end_line")
-                    if (
-                        method_name
-                        and isinstance(start_line, int)
-                        and isinstance(end_line, int)
-                        and class_start <= start_line <= class_end
-                    ):
-                        method_map[method_name] = {
-                            "start_line": start_line,
-                            "end_line": end_line,
-                        }
             _CLASS_INDEX_CACHE[name] = {
+                "type": "class",
                 "file_path": source_file,
                 "superclass": klass.get("superclass"),
+                "includes": klass.get("includes") or [],
                 "start_line": klass.get("start_line"),
                 "end_line": klass.get("end_line"),
-                "methods": method_map,
+                "methods": _contained_method_map(
+                    functions, klass.get("start_line"), klass.get("end_line")
+                ),
+            }
+
+        # Modules are indexed alongside the classes because a controller concern
+        # carries actions, and Ruby resolves them off the same constant name.
+        for module in modules:
+            name = module.get("name")
+            if not name or name in _CLASS_INDEX_CACHE:
+                continue
+            _CLASS_INDEX_CACHE[name] = {
+                "type": "module",
+                "file_path": source_file,
+                "superclass": None,
+                "includes": [],
+                "start_line": module.get("start_line"),
+                "end_line": module.get("end_line"),
+                "methods": _contained_method_map(
+                    functions, module.get("start_line"), module.get("end_line")
+                ),
             }
 
         for func in functions:
@@ -935,6 +1006,28 @@ def _ensure_class_index(directory_path: str) -> Dict[str, Dict[str, object]]:
             )
 
     return _CLASS_INDEX_CACHE
+
+
+def _contained_method_map(functions: List[Dict], start_line, end_line) -> Dict[str, Dict[str, int]]:
+    """The methods a class or module body holds, by name."""
+    method_map: Dict[str, Dict[str, int]] = {}
+    if not isinstance(start_line, int) or not isinstance(end_line, int):
+        return method_map
+    for func in functions:
+        method_name = func.get("name")
+        func_start = func.get("start_line")
+        func_end = func.get("end_line")
+        if (
+            method_name
+            and isinstance(func_start, int)
+            and isinstance(func_end, int)
+            and start_line <= func_start <= end_line
+        ):
+            method_map[method_name] = {
+                "start_line": func_start,
+                "end_line": func_end,
+            }
+    return method_map
 
 
 def _collect_parent_class_names(directory_path: str, class_name: Optional[str]) -> List[str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,4 @@ tree-sitter-javascript==0.23.1
 tree-sitter-ruby==0.23.1
 tree-sitter-go==0.25.0
 tree-sitter-typescript==0.23.2
-esprima==4.0.1
 requests

--- a/run.sh
+++ b/run.sh
@@ -135,7 +135,6 @@ pip3 install \
   "tree-sitter-ruby==0.23.1" \
   "tree-sitter-go==0.25.0" \
   "tree-sitter-typescript==0.23.2" \
-  "esprima==4.0.1" \
   "requests"
 echo "Dependencies installed"
 echo ""

--- a/swagger_generation_cli.py
+++ b/swagger_generation_cli.py
@@ -72,6 +72,12 @@ class RunSwagger:
         try:
             with telemetry.stage(run_id, "scan_repo"):
                 file_paths = self.file_scanner.get_all_file_paths()
+            if not file_paths:
+                print("\n***************************************************")
+                print("No supported source files were found in this repository")
+                print("(looked for .py, .js, .ts, .java, .rb, .go).")
+                print("Nothing was written and no API calls were made.")
+                raise NoEndpointsFound("no supported source files")
 
             print("\n***************************************************")
             with telemetry.stage(run_id, "detect_framework"):
@@ -110,6 +116,15 @@ class RunSwagger:
                             all_endpoints.extend(endpoints)
 
                 with telemetry.stage(run_id, "generate_swagger", {"fast_path": bool(swagger)}):
+                    if not swagger and not all_endpoints:
+                        # No endpoints were extracted; embedding the whole repo
+                        # would spend real money to document nothing.
+                        print("\n***************************************************")
+                        print("No API endpoints were found in this repository.")
+                        print("Nothing was written: swagger.json and the HTML viewer were not created.")
+                        print(f"We detected the framework as '{framework or 'unknown'}'. If that is wrong,")
+                        print("fix the \"framework\" value in apimesh/config.json and run again.")
+                        raise NoEndpointsFound("no endpoints were extracted")
                     if not swagger:
                         print("\n***************************************************")
                         print("Started creating faiss index for all files")
@@ -120,6 +135,8 @@ class RunSwagger:
                         print("Completed Fetching authentication related information")
                         endpoint_related_information = self.endpoints_extractor.get_endpoint_related_information(faiss_vector, all_endpoints)
                         swagger = self.swagger_generator.create_swagger_json(endpoint_related_information, authentication_information, framework, self.user_config['api_host'])
+            except NoEndpointsFound:
+                raise
             except Exception:
                 print("Oops! looks like we encountered an issue. Please try after some time.")
                 raise

--- a/tests/test_core_fixes.py
+++ b/tests/test_core_fixes.py
@@ -829,3 +829,50 @@ def test_legacy_generation_reports_coverage(monkeypatch, tmp_path):
         "skipped_unchanged": 0,
         "failed": 1,
     }
+
+
+def test_no_endpoints_short_circuits_before_embedding(monkeypatch, capsys):
+    """A frontend or marketing folder with zero endpoints must exit cleanly
+    before any embedding spend, not after indexing the whole tree."""
+    runner = swagger_generation_cli.RunSwagger.__new__(swagger_generation_cli.RunSwagger)
+    runner.ai_chat_id = ""
+    runner.user_config = {"framework": "express", "api_host": "https://x.example"}
+    runner.user_configurations = None
+
+    class Scanner:
+        def get_all_file_paths(self):
+            return ["/repo/src/App.js"]
+        def find_api_files(self, file_paths, framework):
+            return []
+
+    class Faiss:
+        def create_faiss_index(self, *a, **k):
+            raise AssertionError("embedding must not run for zero endpoints")
+
+    class Telemetry:
+        def new_run_id(self):
+            return "r"
+        def capture(self, *a, **k):
+            pass
+        def stage(self, *a, **k):
+            import contextlib
+            return contextlib.nullcontext()
+
+    runner.file_scanner = Scanner()
+    runner.faiss_index = Faiss()
+    runner.telemetry = Telemetry()
+    runner.framework_identifier = None
+    runner.endpoints_extractor = None
+    runner.swagger_generator = None
+
+    def fake_pipeline(self, framework):
+        return None
+
+    monkeypatch.setattr(
+        swagger_generation_cli.RunSwagger, "run_python_nodejs_ruby", fake_pipeline
+    )
+    with pytest.raises(swagger_generation_cli.NoEndpointsFound):
+        runner.run("")
+    out = capsys.readouterr().out
+    assert "No API endpoints were found" in out
+    assert "Started creating faiss index" not in out

--- a/tests/test_rails_pipeline_fixes.py
+++ b/tests/test_rails_pipeline_fixes.py
@@ -19,7 +19,10 @@ from rails_pipeline import definition_swagger_generator as generator_module
 from rails_pipeline import run_swagger_generation as run_module
 from rails_pipeline.find_api_definition_files import find_api_definition_files
 from rails_pipeline.generate_file_information import process_file
-from rails_pipeline.identify_api_functions import find_api_endpoints
+from rails_pipeline.identify_api_functions import (
+    collect_route_concerns,
+    find_api_endpoints,
+)
 from rails_pipeline.run_swagger_generation import (
     CONTEXT_TOKEN_BUDGET,
     _batch_endpoint_jobs,
@@ -1593,6 +1596,47 @@ def test_split_route_files_compose_into_one_route_map(tmp_path):
     }
 
 
+SHARED_CONCERN_MAIN_ROUTES = """Rails.application.routes.draw do
+  concern :commentable do
+    resources :comments, only: [:index]
+  end
+end
+"""
+
+# The accented comment shifts every byte offset in this file, so a concern
+# replayed against this buffer instead of its own reads garbage.
+SHARED_CONCERN_ADMIN_ROUTES = """# routes d'André
+resources :posts, only: [:index], concerns: :commentable
+"""
+
+
+def test_a_concern_defined_in_another_route_file_replays(tmp_path):
+    """config/routes.rb defines the concern, config/routes/admin.rb uses it.
+
+    The referencing file is walked first here, which only composes because the
+    concern tables of every route file are merged before the first walk.
+    """
+    routes = _write(tmp_path / "config" / "routes.rb", SHARED_CONCERN_MAIN_ROUTES)
+    admin = _write(
+        tmp_path / "config" / "routes" / "admin.rb", SHARED_CONCERN_ADMIN_ROUTES
+    )
+    concerns = collect_route_concerns([admin, routes])
+
+    route_map: dict = {}
+    for route_file in (admin, routes):
+        find_api_endpoints(route_file, str(tmp_path), route_map, concerns=concerns)
+
+    assert {
+        controller: {
+            (route["verb"], route["path"], route["action"]) for route in entries
+        }
+        for controller, entries in route_map.items()
+    } == {
+        "posts": {("GET", "/posts", "index")},
+        "comments": {("GET", "/posts/:post_id/comments", "index")},
+    }
+
+
 ENGINE_ROUTES = """Rails.application.routes.draw do
   resources :invoices, only: [:index]
 end
@@ -1770,6 +1814,82 @@ def test_an_inherited_action_documents_the_parent_method(tmp_path, monkeypatch):
     assert show["start_line"] == 2 and show["end_line"] == 4
 
 
+TRACKABLE_CONCERN = """module Trackable
+  extend ActiveSupport::Concern
+
+  def track
+    render json: { tracked: true }
+  end
+end
+"""
+
+CONCERN_CONTROLLER = """class SignalsController < ApplicationController
+  include Trackable
+
+  def index
+    render json: []
+  end
+end
+"""
+
+CONCERN_ACTION_ROUTES = """Rails.application.routes.draw do
+  get '/signals/track', to: 'signals#track'
+  resources :signals, only: [:index]
+end
+"""
+
+
+def test_an_action_from_an_included_concern_documents_the_module_method(
+    tmp_path, monkeypatch
+):
+    """`track` lives in an included module, and only superclasses were walked."""
+    repo_root = tmp_path / "concern_app"
+    _write(repo_root / "config" / "routes.rb", CONCERN_ACTION_ROUTES)
+    concern = _write(
+        repo_root / "app" / "controllers" / "concerns" / "trackable.rb",
+        TRACKABLE_CONCERN,
+    )
+    controller = _write(
+        repo_root / "app" / "controllers" / "signals_controller.rb", CONCERN_CONTROLLER
+    )
+    class_index = _build_class_index(monkeypatch, repo_root, tmp_path / "out")
+
+    route_map: dict = {}
+    find_api_endpoints(repo_root / "config" / "routes.rb", str(repo_root), route_map)
+    dropped: list = []
+    endpoints = find_api_endpoints(
+        controller, str(repo_root), route_map, class_index, dropped
+    )
+
+    methods = {method["route"]: method for method in endpoints[0]["methods"]}
+    assert dropped == []
+    assert set(methods) == {"/signals", "/signals/track"}
+    track = methods["/signals/track"]
+    assert track["file_path"] == str(concern)
+    assert track["inherited_from"] == "Trackable"
+    assert track["start_line"] == 4 and track["end_line"] == 6
+
+
+def test_one_class_yields_exactly_one_class_entry(tmp_path):
+    """`class` is also the type of the bare keyword token, so matching it put a
+    phantom anonymous entry in the metadata and in the class index."""
+    controller = _write(
+        tmp_path / "app" / "controllers" / "signals_controller.rb", CONCERN_CONTROLLER
+    )
+    concern = _write(
+        tmp_path / "app" / "controllers" / "concerns" / "trackable.rb", TRACKABLE_CONCERN
+    )
+
+    controller_elements = process_file(str(controller), str(tmp_path))["elements"]
+    assert [item["name"] for item in controller_elements["classes"]] == [
+        "SignalsController"
+    ]
+    assert controller_elements["classes"][0]["includes"] == ["Trackable"]
+
+    concern_elements = process_file(str(concern), str(tmp_path))["elements"]
+    assert [item["name"] for item in concern_elements["modules"]] == ["Trackable"]
+
+
 HELPER_CONTROLLER = """class HelperWidgetsController < ApplicationController
   def show
     set_widget
@@ -1842,6 +1962,104 @@ def test_the_class_index_is_complete_before_the_workers_start(tmp_path, monkeypa
 
     assert expected
     assert seen and all(view == expected for view in seen)
+
+
+HOP_PARENT_BEFORE = """class AuditedController < ApplicationController
+  def audit
+    Rails.logger.info('first')
+  end
+end
+"""
+
+HOP_PARENT_AFTER = """class AuditedController < ApplicationController
+  def audit
+    Rails.logger.info('second')
+  end
+end
+"""
+
+HOP_CHILD_CONTROLLER = """class WidgetsController < AuditedController
+  def index
+    render json: []
+  end
+end
+"""
+
+HOP_SIBLING_CONTROLLER = """class GadgetsController < ApplicationController
+  def index
+    render json: []
+  end
+end
+"""
+
+HOP_ROUTES = """Rails.application.routes.draw do
+  resources :widgets, only: [:index]
+  resources :gadgets, only: [:index]
+end
+"""
+
+
+def test_editing_the_parent_controller_marks_the_childs_endpoint_dirty(
+    tmp_path, monkeypatch
+):
+    """Ruby binds no name on require, so the parent file was never an index edge.
+
+    Without it the second run reads the child's endpoint as untouched and never
+    documents the parent's new body.
+    """
+    repo_root = tmp_path / "hop_app"
+    _write(repo_root / "config" / "routes.rb", HOP_ROUTES)
+    parent = _write(
+        repo_root / "app" / "controllers" / "audited_controller.rb", HOP_PARENT_BEFORE
+    )
+    _write(
+        repo_root / "app" / "controllers" / "widgets_controller.rb",
+        HOP_CHILD_CONTROLLER,
+    )
+    _write(
+        repo_root / "app" / "controllers" / "gadgets_controller.rb",
+        HOP_SIBLING_CONTROLLER,
+    )
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    output_filepath = _prepare_run(monkeypatch, repo_root, output_dir)
+    monkeypatch.setattr(run_module, "get_git_commit_hash", lambda: "base")
+
+    requested = []
+
+    def _fake_batch(endpoints_list, shared_context, sections):
+        requested.append(endpoints_list)
+        return {
+            "paths": {
+                "/widgets": {"get": {"summary": "widgets"}},
+                "/gadgets": {"get": {"summary": "gadgets"}},
+            }
+        }
+
+    monkeypatch.setattr(run_module, "get_batch_definition_swagger", _fake_batch)
+
+    first = run_swagger_generation("http://localhost:3000")
+    # The caller persists the spec between runs, the pipeline reads it back.
+    output_filepath.write_text(json.dumps(first), encoding="utf-8")
+
+    api_index = json.loads((output_dir / "api_index.json").read_text(encoding="utf-8"))
+    widgets_files = api_index["GET /widgets"]["files"]
+    assert [
+        (item["name"], item["file_path"]) for item in widgets_files[0]["imports"]
+    ] == [("AuditedController", os.path.abspath(str(parent)))]
+
+    _write(parent, HOP_PARENT_AFTER)
+    monkeypatch.setattr(
+        run_module,
+        "get_changed_files_since",
+        lambda *args, **kwargs: {os.path.abspath(str(parent))},
+    )
+    monkeypatch.setattr(run_module, "get_git_commit_hash", lambda: "head")
+    requested.clear()
+
+    run_swagger_generation("http://localhost:3000")
+
+    assert requested == ["GET /widgets"]
 
 
 MOVED_BASE_BEFORE = """class BaseController < ApplicationController

--- a/tests/test_rails_pipeline_fixes.py
+++ b/tests/test_rails_pipeline_fixes.py
@@ -1884,10 +1884,207 @@ def test_one_class_yields_exactly_one_class_entry(tmp_path):
     assert [item["name"] for item in controller_elements["classes"]] == [
         "SignalsController"
     ]
-    assert controller_elements["classes"][0]["includes"] == ["Trackable"]
+    assert controller_elements["classes"][0]["includes"] == [["Trackable"]]
 
     concern_elements = process_file(str(concern), str(tmp_path))["elements"]
     assert [item["name"] for item in concern_elements["modules"]] == ["Trackable"]
+
+
+FIRST_TOUCH_CONCERN = """module FirstTouch
+  def track
+    render json: { from: "first" }
+  end
+end
+"""
+
+SECOND_TOUCH_CONCERN = """module SecondTouch
+  def track
+    render json: { from: "second" }
+  end
+end
+"""
+
+ONE_STATEMENT_CONTROLLER = """class SignalsController < ApplicationController
+  include FirstTouch, SecondTouch
+
+  def index
+    render json: []
+  end
+end
+"""
+
+TWO_STATEMENT_CONTROLLER = """class SignalsController < ApplicationController
+  include FirstTouch
+  include SecondTouch
+
+  def index
+    render json: []
+  end
+end
+"""
+
+
+def _stage_include_app(monkeypatch, tmp_path, controller_source: str):
+    """A controller including both concerns, and the class index for the run."""
+    repo_root = tmp_path / "include_app"
+    _write(repo_root / "config" / "routes.rb", CONCERN_ACTION_ROUTES)
+    first = _write(
+        repo_root / "app" / "controllers" / "concerns" / "first_touch.rb",
+        FIRST_TOUCH_CONCERN,
+    )
+    second = _write(
+        repo_root / "app" / "controllers" / "concerns" / "second_touch.rb",
+        SECOND_TOUCH_CONCERN,
+    )
+    controller = _write(
+        repo_root / "app" / "controllers" / "signals_controller.rb", controller_source
+    )
+    class_index = _build_class_index(monkeypatch, repo_root, tmp_path / "out")
+
+    route_map: dict = {}
+    find_api_endpoints(repo_root / "config" / "routes.rb", str(repo_root), route_map)
+    dropped: list = []
+    endpoints = find_api_endpoints(
+        controller, str(repo_root), route_map, class_index, dropped
+    )
+    methods = {method["route"]: method for method in endpoints[0]["methods"]}
+    return first, second, methods, dropped
+
+
+def test_the_first_argument_of_one_include_statement_wins(tmp_path, monkeypatch):
+    """`include FirstTouch, SecondTouch` puts FirstTouch nearest the class."""
+    first, _second, methods, dropped = _stage_include_app(
+        monkeypatch, tmp_path, ONE_STATEMENT_CONTROLLER
+    )
+
+    assert dropped == []
+    track = methods["/signals/track"]
+    assert track["inherited_from"] == "FirstTouch"
+    assert track["file_path"] == str(first)
+
+
+def test_the_later_include_statement_wins(tmp_path, monkeypatch):
+    """Included one statement at a time, the most recent module sits nearest."""
+    _first, second, methods, dropped = _stage_include_app(
+        monkeypatch, tmp_path, TWO_STATEMENT_CONTROLLER
+    )
+
+    assert dropped == []
+    track = methods["/signals/track"]
+    assert track["inherited_from"] == "SecondTouch"
+    assert track["file_path"] == str(second)
+
+
+AUDITABLE_CONCERN = """module Auditable
+  def track
+    render json: { audited: true }
+  end
+end
+"""
+
+NESTING_CONCERN = """module Trackable
+  extend ActiveSupport::Concern
+
+  include Auditable
+end
+"""
+
+
+def test_a_module_included_by_an_included_module_resolves(tmp_path, monkeypatch):
+    """Trackable holds no action of its own; the module it includes does."""
+    repo_root = tmp_path / "nested_include_app"
+    _write(repo_root / "config" / "routes.rb", CONCERN_ACTION_ROUTES)
+    auditable = _write(
+        repo_root / "app" / "controllers" / "concerns" / "auditable.rb",
+        AUDITABLE_CONCERN,
+    )
+    _write(
+        repo_root / "app" / "controllers" / "concerns" / "trackable.rb",
+        NESTING_CONCERN,
+    )
+    controller = _write(
+        repo_root / "app" / "controllers" / "signals_controller.rb", CONCERN_CONTROLLER
+    )
+    class_index = _build_class_index(monkeypatch, repo_root, tmp_path / "out")
+
+    route_map: dict = {}
+    find_api_endpoints(repo_root / "config" / "routes.rb", str(repo_root), route_map)
+    dropped: list = []
+    endpoints = find_api_endpoints(
+        controller, str(repo_root), route_map, class_index, dropped
+    )
+
+    methods = {method["route"]: method for method in endpoints[0]["methods"]}
+    assert dropped == []
+    track = methods["/signals/track"]
+    assert track["inherited_from"] == "Auditable"
+    assert track["file_path"] == str(auditable)
+
+    # The same chain records the edges, so editing Auditable dirties the endpoint.
+    edge_files = {
+        item["file_path"]
+        for item in run_module._ancestor_definition_imports(
+            "SignalsController", "/signals/track"
+        )
+    }
+    assert os.path.abspath(str(auditable)) in edge_files
+
+
+CLASS_METHODS_CONCERN = """module Purgeable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def purge
+      where(purged: true)
+    end
+  end
+end
+"""
+
+CLASS_METHODS_CONTROLLER = """class SignalsController < ApplicationController
+  include Purgeable
+
+  def index
+    render json: []
+  end
+end
+"""
+
+CLASS_METHODS_ROUTES = """Rails.application.routes.draw do
+  get '/signals/purge', to: 'signals#purge'
+  resources :signals, only: [:index]
+end
+"""
+
+
+def test_a_nested_class_methods_module_is_not_an_action(tmp_path, monkeypatch):
+    """`Purgeable::ClassMethods#purge` is not an action Rails would route to."""
+    repo_root = tmp_path / "class_methods_app"
+    _write(repo_root / "config" / "routes.rb", CLASS_METHODS_ROUTES)
+    _write(
+        repo_root / "app" / "controllers" / "concerns" / "purgeable.rb",
+        CLASS_METHODS_CONCERN,
+    )
+    controller = _write(
+        repo_root / "app" / "controllers" / "signals_controller.rb",
+        CLASS_METHODS_CONTROLLER,
+    )
+    class_index = _build_class_index(monkeypatch, repo_root, tmp_path / "out")
+
+    # The method belongs to the nested module alone, never to its enclosing one.
+    assert class_index["Purgeable"]["methods"] == {}
+    assert set(class_index["ClassMethods"]["methods"]) == {"purge"}
+
+    route_map: dict = {}
+    find_api_endpoints(repo_root / "config" / "routes.rb", str(repo_root), route_map)
+    dropped: list = []
+    endpoints = find_api_endpoints(
+        controller, str(repo_root), route_map, class_index, dropped
+    )
+
+    methods = {method["route"]: method for method in endpoints[0]["methods"]}
+    assert set(methods) == {"/signals"}
+    assert dropped == ["GET /signals/purge (signals#purge)"]
 
 
 HELPER_CONTROLLER = """class HelperWidgetsController < ApplicationController


### PR DESCRIPTION
Closes the follow-ups list from the audit remediation (#64, #65).

**Rails**: actions provided by included modules (controller concerns) now resolve through Ruby's real ancestry (one shared linearization: later includes first, argument order within a statement, recursive module includes, then superclass), and those ancestor files become dependency edges so editing a parent controller or concern invalidates dependent endpoints. Route concerns replay across split route files (byte-offset safe). Nested ClassMethods modules no longer masquerade as instance actions. Phantom anonymous class entries are gone.

**Zero-spend empty runs**: a folder with no supported source files exits before any API call; a repo whose extraction finds zero endpoints (frontend apps, marketing sites) exits before the fallback would embed the whole tree. Clean message, exit 1, nothing written.

**Cleanup**: the dead esprima dependency is out of requirements.txt and both install scripts.

Suite: 429 tests, all green. One accepted wontfix recorded: a Go chi builder mounted under two prefixes keeps the first (rare shape; Node covers the common multi-mount case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)