### PR TITLE
Java Spring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ docker run --pull always --rm -v $(pwd):/workspace \
 | Node.js / TypeScript | Express (incl. mounted routers), NestJS | tree-sitter |
 | Ruby on Rails | resources/resource, namespaces, scopes, member/collection, concerns, shallow nesting, engines, split route files | tree-sitter |
 | Go | gin, echo, chi, fiber, gorilla/mux, net/http (incl. Go 1.22 patterns) | tree-sitter |
+| Java | Spring annotation-based controllers (@RestController, @RequestMapping, verb mappings) | tree-sitter |
 | Anything else | Generic LLM extraction fallback | LLM |
 
 ## How it works

--- a/bootstrap_mcp_runner.sh
+++ b/bootstrap_mcp_runner.sh
@@ -102,6 +102,7 @@ pip3 install \
   "tree-sitter-ruby==0.23.1" \
   "tree-sitter-go==0.25.0" \
   "tree-sitter-typescript==0.23.2" \
+  "tree-sitter-java==0.23.5" \
   "requests"
 
 # --- repo setup (clone/update specific branch) ---

--- a/java_pipeline/definition_swagger_generator.py
+++ b/java_pipeline/definition_swagger_generator.py
@@ -1,0 +1,183 @@
+import json
+import time
+from typing import List, Optional, Sequence, Tuple
+
+import pipeline_common
+from llm_client import OpenAiClient
+from prompts import (
+    batch_swagger_generation_prompt,
+    batch_swagger_generation_system_prompt,
+    generic_swagger_generation_prompt,
+    swagger_generation_system_prompt,
+)
+from utils import num_tokens_from_string
+
+
+_API_RETRY_DELAYS = pipeline_common.API_RETRY_DELAYS
+CONTEXT_TOKEN_BUDGET = pipeline_common.CONTEXT_TOKEN_BUDGET
+_EFFECTIVE_CONTEXT_BUDGET = pipeline_common.EFFECTIVE_CONTEXT_BUDGET
+HANDLER_TOKEN_BUDGET = pipeline_common.MAX_HANDLER_TOKENS
+_TRUNCATION_MARKER = "\n... truncated\n"
+_FRAMEWORK_LABEL = "Java Spring"
+_FRAMEWORK_NOTES = "6. Paths already use OpenAPI {param} templating."
+
+
+def _call_with_retry(client: OpenAiClient, messages: List[dict]) -> str:
+    # Transient API failures get two retries; a persistent one propagates so the
+    # caller can drop this endpoint instead of the whole run.
+    for delay in _API_RETRY_DELAYS:
+        try:
+            return client.call_chat_completion(messages=messages, temperature=0)
+        except Exception:
+            time.sleep(delay)
+    return client.call_chat_completion(messages=messages, temperature=0)
+
+
+def _extract_json_block(raw_text: str) -> Optional[str]:
+    if not raw_text:
+        return None
+    start = raw_text.find("{")
+    end = raw_text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    return raw_text[start : end + 1]
+
+
+def _cleanup_swagger_payload(payload: dict) -> dict:
+    paths = payload.get("paths", {})
+    if not isinstance(paths, dict):
+        return payload
+    for path_data in paths.values():
+        if not isinstance(path_data, dict):
+            continue
+        for method_data in path_data.values():
+            # A path item can hold non-operation values such as "parameters": [].
+            if not isinstance(method_data, dict):
+                continue
+            # The sample output shows an empty auth tag, and older replies still
+            # use the pre-extension key name.
+            for auth_tag_key in ("x-auth-tag", "auth_tag"):
+                auth_tag = method_data.get(auth_tag_key)
+                if auth_tag is None or str(auth_tag).strip() == "":
+                    method_data.pop(auth_tag_key, None)
+    return payload
+
+
+def build_endpoint_section(label: str, body) -> Tuple[str, bool]:
+    """One endpoint's prompt section, with its handler capped."""
+    return pipeline_common.handler_section(
+        f"{label}:", body, HANDLER_TOKEN_BUDGET, _TRUNCATION_MARKER
+    )
+
+
+def section_token_cost(label: str, body) -> int:
+    """What one endpoint's section costs against the batch budget.
+
+    The caller packs batches with this, so it has to price exactly the section
+    the prompt ends up carrying, truncation marker included.
+    """
+    section, _ = build_endpoint_section(label, body)
+    return num_tokens_from_string(section)
+
+
+def build_batch_prompt(
+    endpoint_entries: Sequence[Tuple[str, str]],
+    context_blocks,
+    source_file: str,
+) -> str:
+    """One prompt covering a file's endpoints, inside the context budget."""
+    sections: List[str] = []
+    handler_tokens = 0
+    truncated = False
+    for label, body in endpoint_entries:
+        section, was_truncated = build_endpoint_section(label, body)
+        truncated = truncated or was_truncated
+        handler_tokens += num_tokens_from_string(section)
+        sections.append(section)
+    kept, dropped = pipeline_common.fit_context(
+        context_blocks, max(_EFFECTIVE_CONTEXT_BUDGET - handler_tokens, 0)
+    )
+    pipeline_common.report_context_trim(source_file, dropped, truncated)
+    return batch_swagger_generation_prompt.format(
+        framework_label=_FRAMEWORK_LABEL,
+        framework_notes=_FRAMEWORK_NOTES,
+        endpoints_list="\n".join(label for label, _ in endpoint_entries),
+        shared_context="\n\n".join(kept),
+        per_endpoint_sections="\n\n".join(sections),
+    )
+
+
+def get_batch_definition_swagger(
+    endpoint_entries: Sequence[Tuple[str, str]],
+    context_blocks,
+    source_file: str,
+) -> Optional[dict]:
+    """The model's paths payload for one file's endpoints, None when unusable.
+
+    A second unusable reply is not worth a third batch call: the caller spends
+    per-endpoint calls on those endpoints instead.
+    """
+    client = OpenAiClient()
+    messages = [
+        {"role": "system", "content": batch_swagger_generation_system_prompt},
+        {
+            "role": "user",
+            "content": build_batch_prompt(endpoint_entries, context_blocks, source_file),
+        },
+    ]
+    for _ in range(2):
+        response = _call_with_retry(client, messages)
+        payload = _extract_json_block(response)
+        if not payload:
+            continue
+        try:
+            parsed = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and isinstance(parsed.get("paths"), dict):
+            return _cleanup_swagger_payload(parsed)
+    return None
+
+
+def get_function_definition_swagger(
+    function_definition: List[str],
+    context: List[List[str]],
+    route: str,
+    http_method: Optional[str] = None,
+    source_file: Optional[str] = None,
+) -> dict:
+    client = OpenAiClient()
+    function_text, truncated = pipeline_common.truncate_to_tokens(
+        "".join(function_definition), HANDLER_TOKEN_BUDGET, _TRUNCATION_MARKER
+    )
+    kept, dropped = pipeline_common.fit_context(
+        context,
+        max(_EFFECTIVE_CONTEXT_BUDGET - num_tokens_from_string(function_text), 0),
+    )
+    pipeline_common.report_context_trim(source_file or route, dropped, truncated)
+    context_text = "\n\n".join(kept)
+
+    prompt = generic_swagger_generation_prompt.format(
+        endpoint_method=http_method or "GET",
+        endpoint_path=route,
+        endpoint_info=function_text,
+        authentication_information=context_text,
+    )
+
+    messages = [
+        {"role": "system", "content": swagger_generation_system_prompt},
+        {"role": "user", "content": prompt},
+    ]
+
+    last_error: Optional[Exception] = None
+    for _ in range(3):
+        response = _call_with_retry(client, messages)
+        payload = _extract_json_block(response)
+        if not payload:
+            last_error = ValueError("LLM response was missing JSON payload.")
+            continue
+        try:
+            return _cleanup_swagger_payload(json.loads(payload))
+        except json.JSONDecodeError as exc:
+            last_error = exc
+    raise ValueError("Unable to parse Swagger JSON response.") from last_error

--- a/java_pipeline/find_api_definition_files.py
+++ b/java_pipeline/find_api_definition_files.py
@@ -1,0 +1,58 @@
+import re
+from pathlib import Path
+from typing import List
+
+from config import Configurations
+
+config = Configurations()
+
+# The annotations that make a file worth parsing. A file carrying none of them
+# defines no Spring endpoint, and the extractor would walk it for nothing.
+SPRING_WEB_ANNOTATIONS = (
+    "RestController",
+    "Controller",
+    "RequestMapping",
+    "GetMapping",
+    "PostMapping",
+    "PutMapping",
+    "DeleteMapping",
+    "PatchMapping",
+)
+
+_ANNOTATION_PATTERN = re.compile(
+    r"@\s*(?:" + "|".join(SPRING_WEB_ANNOTATIONS) + r")\b"
+)
+
+
+def _is_ignored(path: Path, base_path: Path) -> bool:
+    # Only components below the scanned repo may be ignored, otherwise a repo
+    # living under /var, /tmp or /build discovers nothing.
+    try:
+        relative = path.relative_to(base_path)
+    except ValueError:
+        relative = path
+    return any(part in config.ignored_dirs for part in relative.parts)
+
+
+def find_java_files(directory: str) -> List[Path]:
+    base_path = Path(directory)
+    java_files: List[Path] = []
+    for file_path in base_path.rglob("*.java"):
+        if _is_ignored(file_path, base_path):
+            continue
+        java_files.append(file_path)
+    return java_files
+
+
+def file_contains_api_defs(file_path: Path) -> bool:
+    try:
+        text = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return bool(_ANNOTATION_PATTERN.search(text))
+
+
+def find_api_definition_files(directory: str) -> List[str]:
+    java_files = find_java_files(directory)
+    java_files.sort()
+    return [str(path) for path in java_files if file_contains_api_defs(path)]

--- a/java_pipeline/generate_file_information.py
+++ b/java_pipeline/generate_file_information.py
@@ -1,0 +1,310 @@
+import os
+from typing import Dict, List, Optional, Tuple
+
+from tree_sitter import Language, Parser
+import tree_sitter_java
+
+from config import Configurations
+
+config = Configurations()
+
+JAVA_LANGUAGE = Language(tree_sitter_java.language())
+parser = Parser(JAVA_LANGUAGE)
+
+# repo root -> (java files by basename, the directories holding them). Java
+# resolves an import by package path, so the whole scan set is what says which
+# file com.acme.service.UserService is.
+_SOURCE_INDEX_CACHE: Dict[str, Tuple[Dict[str, List[str]], List[str]]] = {}
+
+# Declarations that carry a type another file can import.
+_TYPE_DECLARATIONS = {
+    "class_declaration": "class",
+    "interface_declaration": "interface",
+    "enum_declaration": "enum",
+    "record_declaration": "class",
+    "annotation_type_declaration": "interface",
+}
+
+_METHOD_DECLARATIONS = {
+    "method_declaration": "function",
+    "constructor_declaration": "function",
+}
+
+
+def parse_file(filename: str):
+    # Read and parse bytes: decoding as strict utf-8 first threw away the
+    # metadata of every file that is not utf-8, and tree-sitter works on bytes
+    # anyway.
+    with open(filename, "rb") as f:
+        code = f.read()
+    tree = parser.parse(code)
+    return tree, code
+
+
+def _node_text(source: bytes, node) -> str:
+    # tree-sitter offsets are byte offsets, so slice the bytes and decode.
+    return source[node.start_byte : node.end_byte].decode("utf-8", "replace")
+
+
+def reset_source_index() -> None:
+    """The same checkout path can hold different java sources on the next run."""
+    _SOURCE_INDEX_CACHE.clear()
+
+
+def _source_index(base_directory: str) -> Tuple[Dict[str, List[str]], List[str]]:
+    """Every java file below the repo root, by basename, and their directories."""
+    cached = _SOURCE_INDEX_CACHE.get(base_directory)
+    if cached is not None:
+        return cached
+    by_basename: Dict[str, List[str]] = {}
+    directories = set()
+    for root, dirs, files in os.walk(base_directory):
+        dirs[:] = [name for name in dirs if name not in config.ignored_dirs]
+        for filename in files:
+            if not filename.endswith(".java"):
+                continue
+            by_basename.setdefault(filename, []).append(os.path.join(root, filename))
+            directories.add(root)
+    for paths in by_basename.values():
+        paths.sort()
+    index = (by_basename, sorted(directories))
+    _SOURCE_INDEX_CACHE[base_directory] = index
+    return index
+
+
+def _resolve_type_origin(segments: List[str], base_directory: Optional[str]) -> Optional[str]:
+    """The file declaring com.acme.service.UserService, when the repo holds it.
+
+    A java file sits under its package path, so the import is a path suffix:
+    any scanned file ending in com/acme/service/UserService.java is the one.
+    """
+    if not base_directory or not segments:
+        return None
+    by_basename, _ = _source_index(base_directory)
+    suffix = os.sep + os.path.join(*segments) + ".java"
+    for candidate in by_basename.get(f"{segments[-1]}.java", []):
+        if candidate.endswith(suffix):
+            return os.path.normpath(candidate)
+    return None
+
+
+def _resolve_package_origin(segments: List[str], base_directory: Optional[str]) -> Optional[str]:
+    """The directory holding com.acme.service, for a wildcard import."""
+    if not base_directory or not segments:
+        return None
+    _, directories = _source_index(base_directory)
+    suffix = os.sep + os.path.join(*segments)
+    for candidate in directories:
+        if candidate.endswith(suffix):
+            return os.path.normpath(candidate)
+    return None
+
+
+def _package_class_names(origin: Optional[str]) -> List[str]:
+    """The types a wildcard import can bind, read off the package directory."""
+    if not origin or not os.path.isdir(origin):
+        return []
+    try:
+        entries = sorted(os.listdir(origin))
+    except OSError:
+        return []
+    return [name[: -len(".java")] for name in entries if name.endswith(".java")]
+
+
+def _import_statement(node, source: bytes) -> Tuple[List[str], bool, bool]:
+    """(name segments, is static, is wildcard) of one import declaration."""
+    text = _node_text(source, node).strip().rstrip(";").strip()
+    if text.startswith("import"):
+        text = text[len("import") :].strip()
+    is_static = text.startswith("static")
+    if is_static:
+        text = text[len("static") :].strip()
+    is_wildcard = text.endswith(".*")
+    if is_wildcard:
+        text = text[: -len(".*")]
+    segments = [segment.strip() for segment in text.split(".") if segment.strip()]
+    return segments, is_static, is_wildcard
+
+
+def _collect_imports(root, source: bytes, base_directory: Optional[str]) -> List[Dict]:
+    """One entry per import, resolved to the file or package it names.
+
+    ``imported_name`` is the simple type name, which is also how the name is
+    written at every usage site, so dependency matching works the way it does
+    in the other pipelines.
+    """
+    imports: List[Dict] = []
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node.type == "import_declaration":
+            segments, is_static, is_wildcard = _import_statement(node, source)
+            if not segments:
+                continue
+            if is_static:
+                # ``import static com.acme.Paths.USERS`` names a member of a
+                # type, so the type is what resolves to a file.
+                origin = _resolve_type_origin(
+                    segments if is_wildcard else segments[:-1], base_directory
+                )
+                imported_name = segments[-1] if not is_wildcard else "*"
+                names = [imported_name] if not is_wildcard else []
+            elif is_wildcard:
+                origin = _resolve_package_origin(segments, base_directory)
+                imported_name = "*"
+                names = _package_class_names(origin)
+            else:
+                origin = _resolve_type_origin(segments, base_directory)
+                imported_name = segments[-1]
+                names = [imported_name]
+            imports.append(
+                {
+                    "type": "import",
+                    "imported_name": imported_name,
+                    "from_module": ".".join(segments),
+                    "origin": origin,
+                    "line": node.start_point[0] + 1,
+                    "path_exists": bool(origin and os.path.exists(origin)),
+                    "usage_lines": [],
+                    "usages": [],
+                    "_names": names,
+                }
+            )
+        stack.extend(list(node.children))
+    return imports
+
+
+def _annotate_import_usages(root, source: bytes, imports: List[Dict]) -> None:
+    """Record where each imported name is used, and which name it was.
+
+    A wildcard import binds every type of its package, so the usage carries the
+    name the handler actually reached for and the resolver looks that one up.
+    """
+    name_map: Dict[str, List[Dict]] = {}
+    for item in imports:
+        for name in item.get("_names") or []:
+            name_map.setdefault(name, []).append(item)
+    if not name_map:
+        return
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node.type in {"identifier", "type_identifier"}:
+            entries = name_map.get(_node_text(source, node))
+            if entries:
+                line = node.start_point[0] + 1
+                for entry in entries:
+                    if line == entry["line"]:
+                        continue
+                    if line not in entry["usage_lines"]:
+                        entry["usage_lines"].append(line)
+                    usage = {"name": _node_text(source, node), "line": line}
+                    if usage not in entry["usages"]:
+                        entry["usages"].append(usage)
+        stack.extend(list(node.children))
+    for item in imports:
+        item.pop("_names", None)
+        item["usage_lines"].sort()
+
+
+def _declarator_names(node, source: bytes) -> List[str]:
+    names = []
+    for child in node.children:
+        if child.type != "variable_declarator":
+            continue
+        name_node = child.child_by_field_name("name")
+        if name_node is not None:
+            names.append(_node_text(source, name_node))
+    return names
+
+
+def _collect_elements(root, source: bytes) -> Dict:
+    elements: Dict = {
+        "classes": [],
+        "functions": [],
+        "variables": [],
+        "function_calls": [],
+    }
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        node_type = node.type
+        if node_type in _TYPE_DECLARATIONS:
+            name_node = node.child_by_field_name("name")
+            if name_node is not None:
+                elements["classes"].append(
+                    {
+                        "type": _TYPE_DECLARATIONS[node_type],
+                        "name": _node_text(source, name_node),
+                        "start_line": node.start_point[0] + 1,
+                        "end_line": node.end_point[0] + 1,
+                    }
+                )
+        elif node_type in _METHOD_DECLARATIONS:
+            name_node = node.child_by_field_name("name")
+            if name_node is not None:
+                elements["functions"].append(
+                    {
+                        "type": _METHOD_DECLARATIONS[node_type],
+                        "name": _node_text(source, name_node),
+                        # The declaration node opens at its first annotation,
+                        # so the span carries @GetMapping and the body alike.
+                        "start_line": node.start_point[0] + 1,
+                        "end_line": node.end_point[0] + 1,
+                    }
+                )
+        elif node_type == "field_declaration":
+            for name in _declarator_names(node, source):
+                elements["variables"].append(
+                    {
+                        "type": "variable",
+                        "name": name,
+                        "start_line": node.start_point[0] + 1,
+                        "end_line": node.end_point[0] + 1,
+                    }
+                )
+        elif node_type == "method_invocation":
+            name_node = node.child_by_field_name("name")
+            if name_node is not None:
+                elements["function_calls"].append(
+                    {
+                        "type": "function_call",
+                        "name": _node_text(source, name_node),
+                        "full_name": _node_text(source, node).split("(")[0].strip(),
+                        "start_line": node.start_point[0] + 1,
+                        "end_line": node.end_point[0] + 1,
+                    }
+                )
+        stack.extend(list(node.children))
+    return elements
+
+
+def _attach_call_ranges(functions: List[Dict], calls: List[Dict]) -> None:
+    functions_by_name: Dict[str, Dict] = {}
+    for func in functions:
+        functions_by_name.setdefault(func["name"], func)
+    for call in calls:
+        target = functions_by_name.get(call["name"])
+        if not target:
+            continue
+        call["function_start_line"] = target["start_line"]
+        call["function_end_line"] = target["end_line"]
+
+
+def get_elements(tree, source: bytes, base_directory: Optional[str]):
+    elements = _collect_elements(tree.root_node, source)
+    _attach_call_ranges(elements["functions"], elements["function_calls"])
+    imports = _collect_imports(tree.root_node, source, base_directory)
+    _annotate_import_usages(tree.root_node, source, imports)
+    return elements, imports
+
+
+def process_file(filename: str, base_directory: Optional[str] = None) -> Dict:
+    if not base_directory:
+        base_directory = os.path.dirname(filename)
+    tree, source = parse_file(filename)
+    elements, imports = get_elements(tree, source, base_directory)
+    for key in ("classes", "functions", "variables"):
+        for item in elements.get(key, []):
+            item["file_path"] = filename
+    return {"filename": filename, "elements": elements, "imports": imports}

--- a/java_pipeline/generate_file_information.py
+++ b/java_pipeline/generate_file_information.py
@@ -77,14 +77,20 @@ def _resolve_type_origin(segments: List[str], base_directory: Optional[str]) -> 
 
     A java file sits under its package path, so the import is a path suffix:
     any scanned file ending in com/acme/service/UserService.java is the one.
+    A nested type writes its outer type into that path, so
+    com.acme.Dto.UserRequest is declared in com/acme/Dto.java: the longest
+    prefix that is a file is the origin, and where inside it the nested type
+    sits does not change which file the edge points at.
     """
     if not base_directory or not segments:
         return None
     by_basename, _ = _source_index(base_directory)
-    suffix = os.sep + os.path.join(*segments) + ".java"
-    for candidate in by_basename.get(f"{segments[-1]}.java", []):
-        if candidate.endswith(suffix):
-            return os.path.normpath(candidate)
+    for end in range(len(segments), 0, -1):
+        prefix = segments[:end]
+        suffix = os.sep + os.path.join(*prefix) + ".java"
+        for candidate in by_basename.get(f"{prefix[-1]}.java", []):
+            if candidate.endswith(suffix):
+                return os.path.normpath(candidate)
     return None
 
 

--- a/java_pipeline/identify_api_functions.py
+++ b/java_pipeline/identify_api_functions.py
@@ -1,0 +1,345 @@
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from tree_sitter import Language, Node, Parser
+import tree_sitter_java
+
+JAVA_LANGUAGE = Language(tree_sitter_java.language())
+parser = Parser(JAVA_LANGUAGE)
+
+
+# A class only serves HTTP when one of these sits on it. A mapping annotated
+# method on anything else (a @Service, a plain helper) is not an endpoint.
+CONTROLLER_ANNOTATIONS = {"RestController", "Controller"}
+
+# The shorthand annotations carry their verb in their own name.
+VERB_ANNOTATIONS = {
+    "GetMapping": "GET",
+    "PostMapping": "POST",
+    "PutMapping": "PUT",
+    "DeleteMapping": "DELETE",
+    "PatchMapping": "PATCH",
+}
+
+REQUEST_MAPPING = "RequestMapping"
+
+HTTP_METHODS = {
+    "GET",
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+    "OPTIONS",
+    "HEAD",
+    "TRACE",
+}
+
+# The annotation attributes that carry the path, in the order Spring reads them.
+_PATH_ATTRIBUTES = ("value", "path")
+
+# Where a class or a method declaration keeps its annotations.
+_MODIFIERS = "modifiers"
+_ANNOTATION_TYPES = {"marker_annotation", "annotation"}
+
+# Every declaration that can hold a controller's methods.
+_CLASS_TYPES = {"class_declaration", "interface_declaration"}
+
+# Counted across one extraction run and reported once, so a repo that silently
+# loses routes says so instead of shipping a thin spec.
+_EXTRACTION_DROPS = {"assumed_get": 0, "unresolved": 0}
+
+
+def reset_extraction_drops() -> None:
+    for key in _EXTRACTION_DROPS:
+        _EXTRACTION_DROPS[key] = 0
+
+
+def extraction_drops() -> Dict[str, int]:
+    return dict(_EXTRACTION_DROPS)
+
+
+def log_extraction_drops() -> None:
+    """One line for everything extraction assumed or threw away, or nothing."""
+    assumed_get = _EXTRACTION_DROPS["assumed_get"]
+    unresolved = _EXTRACTION_DROPS["unresolved"]
+    if not assumed_get and not unresolved:
+        return
+    print(
+        f"apimesh: java extraction documented {assumed_get} @RequestMapping "
+        "methods with no method attribute as GET only and skipped "
+        f"{unresolved} mappings whose arguments it could not read"
+    )
+
+
+def _node_text(source: bytes, node: Node) -> str:
+    # tree-sitter offsets are byte offsets, so slice the bytes and decode.
+    return source[node.start_byte : node.end_byte].decode("utf-8", "replace")
+
+
+def _string_literal_value(node: Node, source: bytes) -> Optional[str]:
+    """The text of a plain string literal, or None for anything else.
+
+    A concatenation or a constant reference has no value at parse time, and
+    guessing one would document a path the service does not serve.
+    """
+    if node.type != "string_literal":
+        return None
+    return "".join(
+        _node_text(source, child)
+        for child in node.children
+        if child.type == "string_fragment"
+    )
+
+
+def _simple_name(node: Optional[Node], source: bytes) -> str:
+    """The last segment of a name: org.springframework...GetMapping is GetMapping."""
+    if node is None:
+        return ""
+    return _node_text(source, node).strip().split(".")[-1]
+
+
+def _annotations(declaration: Node) -> List[Node]:
+    # The modifiers of a declaration are a plain child, not a named field, and
+    # the annotations sit inside them.
+    for child in declaration.children:
+        if child.type != _MODIFIERS:
+            continue
+        return [node for node in child.children if node.type in _ANNOTATION_TYPES]
+    return []
+
+
+def _annotation_name(annotation: Node, source: bytes) -> str:
+    return _simple_name(annotation.child_by_field_name("name"), source)
+
+
+def _annotation_by_name(declaration: Node, source: bytes, name: str) -> Optional[Node]:
+    for annotation in _annotations(declaration):
+        if _annotation_name(annotation, source) == name:
+            return annotation
+    return None
+
+
+def _has_controller_annotation(declaration: Node, source: bytes) -> bool:
+    return any(
+        _annotation_name(annotation, source) in CONTROLLER_ANNOTATIONS
+        for annotation in _annotations(declaration)
+    )
+
+
+def _argument_nodes(annotation: Node) -> Sequence[Node]:
+    arguments = annotation.child_by_field_name("arguments")
+    if arguments is None:
+        return ()
+    return [
+        child
+        for child in arguments.children
+        if child.is_named and child.type not in {"(", ")", ","}
+    ]
+
+
+def _attribute_value(annotation: Node, source: bytes, names: Sequence[str]) -> Optional[Node]:
+    """The value node of the first named attribute of this annotation."""
+    for argument in _argument_nodes(annotation):
+        if argument.type != "element_value_pair":
+            continue
+        key = argument.child_by_field_name("key")
+        if key is not None and _node_text(source, key).strip() in names:
+            return argument.child_by_field_name("value")
+    return None
+
+
+def _positional_value(annotation: Node) -> Optional[Node]:
+    """``@GetMapping("/x")`` writes its path without naming the attribute."""
+    for argument in _argument_nodes(annotation):
+        if argument.type != "element_value_pair":
+            return argument
+    return None
+
+
+def _array_elements(node: Node) -> List[Node]:
+    return [
+        child
+        for child in node.children
+        if child.is_named and child.type not in {"{", "}", ","}
+    ]
+
+
+def _annotation_paths(annotation: Node, source: bytes) -> Tuple[List[str], bool]:
+    """The paths one mapping annotation declares, and whether they were readable.
+
+    An annotation with no path attribute at all contributes the empty path, so
+    the endpoint sits on the class prefix alone. One that names a path the
+    parser cannot resolve to literals is unreadable, and the endpoint is
+    dropped rather than documented under an invented route.
+    """
+    value = _attribute_value(annotation, source, _PATH_ATTRIBUTES)
+    if value is None:
+        value = _positional_value(annotation)
+    if value is None:
+        return [""], True
+    if value.type == "element_value_array_initializer":
+        paths = []
+        for element in _array_elements(value):
+            literal = _string_literal_value(element, source)
+            if literal is None:
+                return [], False
+            paths.append(literal)
+        return (paths, True) if paths else ([""], True)
+    literal = _string_literal_value(value, source)
+    if literal is None:
+        return [], False
+    return [literal], True
+
+
+def _request_method_name(node: Node, source: bytes) -> Optional[str]:
+    """``RequestMethod.PUT`` and a statically imported ``PUT`` both read as PUT."""
+    if node.type == "field_access":
+        name = _simple_name(node.child_by_field_name("field"), source)
+    elif node.type in {"identifier", "field_expression", "scoped_identifier"}:
+        name = _simple_name(node, source)
+    else:
+        return None
+    name = name.upper()
+    return name if name in HTTP_METHODS else None
+
+
+def _request_mapping_verbs(annotation: Node, source: bytes) -> Tuple[List[str], bool]:
+    """The verbs a @RequestMapping declares, and whether they were readable.
+
+    A @RequestMapping with no method attribute serves every verb in Spring.
+    OpenAPI would take one operation per verb, all of them invented from a
+    single handler, so only GET is emitted and the assumption is counted.
+    """
+    value = _attribute_value(annotation, source, ("method",))
+    if value is None:
+        _EXTRACTION_DROPS["assumed_get"] += 1
+        return ["GET"], True
+    nodes = (
+        _array_elements(value)
+        if value.type == "element_value_array_initializer"
+        else [value]
+    )
+    verbs = []
+    for node in nodes:
+        verb = _request_method_name(node, source)
+        if verb is None:
+            return [], False
+        verbs.append(verb)
+    return (verbs, True) if verbs else ([], False)
+
+
+def _mapping_annotation(declaration: Node, source: bytes) -> Tuple[Optional[Node], str]:
+    """The mapping annotation a method carries, and its name."""
+    for annotation in _annotations(declaration):
+        name = _annotation_name(annotation, source)
+        if name in VERB_ANNOTATIONS or name == REQUEST_MAPPING:
+            return annotation, name
+    return None, ""
+
+
+def _join_paths(prefix: str, path: str) -> str:
+    """Class prefix plus method path, with no doubled or missing separators."""
+    left = (prefix or "").strip()
+    right = (path or "").strip()
+    if left and not left.startswith("/"):
+        left = f"/{left}"
+    if right and not right.startswith("/"):
+        right = f"/{right}"
+    joined = f"{left.rstrip('/')}{right}"
+    while "//" in joined:
+        joined = joined.replace("//", "/")
+    return joined or "/"
+
+
+def _class_prefixes(declaration: Node, source: bytes) -> Tuple[List[str], bool]:
+    """The prefixes a controller's own @RequestMapping contributes.
+
+    Several of them fan the whole controller out, one endpoint per prefix.
+    """
+    annotation = _annotation_by_name(declaration, source, REQUEST_MAPPING)
+    if annotation is None:
+        return [""], True
+    return _annotation_paths(annotation, source)
+
+
+def _class_methods(declaration: Node) -> List[Node]:
+    """The methods declared directly on this class.
+
+    A nested class is a class of its own: its methods are endpoints only when
+    it carries a controller annotation itself.
+    """
+    body = declaration.child_by_field_name("body")
+    if body is None:
+        return []
+    return [child for child in body.children if child.type == "method_declaration"]
+
+
+def _build_endpoint_entry(
+    route: str, http_method: str, name: str, declaration: Node, file_path: Path
+) -> Dict:
+    return {
+        "type": "function",
+        "method": http_method,
+        "route": route,
+        "name": name,
+        # The declaration node starts at its first annotation, so the span the
+        # prompt reads carries @GetMapping, @PathVariable and the body alike.
+        "start_line": declaration.start_point[0] + 1,
+        "end_line": declaration.end_point[0] + 1,
+        "file_path": str(file_path),
+    }
+
+
+def _endpoints_of_class(
+    declaration: Node, source: bytes, file_path: Path
+) -> List[Dict]:
+    prefixes, readable = _class_prefixes(declaration, source)
+    if not readable:
+        _EXTRACTION_DROPS["unresolved"] += 1
+        return []
+
+    endpoints: List[Dict] = []
+    for method in _class_methods(declaration):
+        annotation, annotation_name = _mapping_annotation(method, source)
+        if annotation is None:
+            continue
+        paths, path_readable = _annotation_paths(annotation, source)
+        if not path_readable:
+            _EXTRACTION_DROPS["unresolved"] += 1
+            continue
+        if annotation_name == REQUEST_MAPPING:
+            verbs, verbs_readable = _request_mapping_verbs(annotation, source)
+            if not verbs_readable:
+                _EXTRACTION_DROPS["unresolved"] += 1
+                continue
+        else:
+            verbs = [VERB_ANNOTATIONS[annotation_name]]
+        name_node = method.child_by_field_name("name")
+        name = _node_text(source, name_node) if name_node else "<anonymous>"
+        for prefix in prefixes:
+            for path in paths:
+                route = _join_paths(prefix, path)
+                for verb in verbs:
+                    endpoints.append(
+                        _build_endpoint_entry(route, verb, name, method, file_path)
+                    )
+    return endpoints
+
+
+def find_api_endpoints(file_path, repo_root: Optional[str] = None) -> List[Dict]:
+    path = Path(file_path)
+    try:
+        source = path.read_bytes()
+    except OSError:
+        return []
+
+    tree = parser.parse(source)
+
+    endpoints: List[Dict] = []
+    stack = [tree.root_node]
+    while stack:
+        node = stack.pop()
+        if node.type in _CLASS_TYPES and _has_controller_annotation(node, source):
+            endpoints.extend(_endpoints_of_class(node, source, path))
+        stack.extend(list(node.children))
+    return endpoints

--- a/java_pipeline/identify_api_functions.py
+++ b/java_pipeline/identify_api_functions.py
@@ -1,8 +1,10 @@
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 from tree_sitter import Language, Node, Parser
 import tree_sitter_java
+
+from java_pipeline.find_api_definition_files import find_api_definition_files
 
 JAVA_LANGUAGE = Language(tree_sitter_java.language())
 parser = Parser(JAVA_LANGUAGE)
@@ -37,21 +39,34 @@ HTTP_METHODS = {
 # The annotation attributes that carry the path, in the order Spring reads them.
 _PATH_ATTRIBUTES = ("value", "path")
 
+# The attributes that narrow a mapping without changing its route. Two handlers
+# on one route and verb are told apart by these.
+_NEGOTIATION_ATTRIBUTES = ("consumes", "produces")
+_PREDICATE_ATTRIBUTES = ("params", "headers")
+_CONDITION_ATTRIBUTES = _NEGOTIATION_ATTRIBUTES + _PREDICATE_ATTRIBUTES
+
 # Where a class or a method declaration keeps its annotations.
 _MODIFIERS = "modifiers"
 _ANNOTATION_TYPES = {"marker_annotation", "annotation"}
-
-# Every declaration that can hold a controller's methods.
-_CLASS_TYPES = {"class_declaration", "interface_declaration"}
 
 # Counted across one extraction run and reported once, so a repo that silently
 # loses routes says so instead of shipping a thin spec.
 _EXTRACTION_DROPS = {"assumed_get": 0, "unresolved": 0}
 
+# Repo root -> the mapping interfaces the scan set declares. An implements
+# clause is resolved against every scanned file, not against one of them, so
+# the index is built once per run and read by every file's extraction.
+_TYPE_INDEX_CACHE: Dict[str, Dict] = {}
+
 
 def reset_extraction_drops() -> None:
     for key in _EXTRACTION_DROPS:
         _EXTRACTION_DROPS[key] = 0
+
+
+def reset_type_index() -> None:
+    """The same checkout path can hold different java sources on the next run."""
+    _TYPE_INDEX_CACHE.clear()
 
 
 def extraction_drops() -> Dict[str, int]:
@@ -67,7 +82,7 @@ def log_extraction_drops() -> None:
     print(
         f"apimesh: java extraction documented {assumed_get} @RequestMapping "
         "methods with no method attribute as GET only and skipped "
-        f"{unresolved} mappings whose arguments it could not read"
+        f"{unresolved} mappings it could not read or place on an implementation"
     )
 
 
@@ -237,6 +252,62 @@ def _mapping_annotation(declaration: Node, source: bytes) -> Tuple[Optional[Node
     return None, ""
 
 
+def _string_values(value: Node, source: bytes) -> List[str]:
+    """The literals one attribute lists. A constant reference contributes none."""
+    nodes = (
+        _array_elements(value)
+        if value.type == "element_value_array_initializer"
+        else [value]
+    )
+    values = []
+    for node in nodes:
+        literal = _string_literal_value(node, source)
+        if literal is not None:
+            values.append(literal)
+    return values
+
+
+def _mapping_conditions(annotation: Node, source: bytes) -> Dict[str, List[str]]:
+    """What narrows a mapping without changing its route.
+
+    consumes, produces, params and headers pick one handler among several on
+    the same route and verb, and they are what the operation has to say about
+    the media types and the parameters it answers on.
+    """
+    conditions: Dict[str, List[str]] = {}
+    for name in _CONDITION_ATTRIBUTES:
+        value = _attribute_value(annotation, source, (name,))
+        if value is None:
+            continue
+        values = _string_values(value, source)
+        if values:
+            conditions[name] = values
+    return conditions
+
+
+def _compose_conditions(
+    class_conditions: Dict[str, List[str]], method_conditions: Dict[str, List[str]]
+) -> Dict[str, List[str]]:
+    """Class level and method level conditions, the way Spring reads them.
+
+    A method's consumes or produces replaces the class's; its params and
+    headers are added to them.
+    """
+    composed: Dict[str, List[str]] = {}
+    for name in _NEGOTIATION_ATTRIBUTES:
+        values = method_conditions.get(name) or class_conditions.get(name)
+        if values:
+            composed[name] = list(values)
+    for name in _PREDICATE_ATTRIBUTES:
+        values = list(class_conditions.get(name) or [])
+        for value in method_conditions.get(name) or []:
+            if value not in values:
+                values.append(value)
+        if values:
+            composed[name] = values
+    return composed
+
+
 def _join_paths(prefix: str, path: str) -> str:
     """Class prefix plus method path, with no doubled or missing separators."""
     left = (prefix or "").strip()
@@ -251,15 +322,38 @@ def _join_paths(prefix: str, path: str) -> str:
     return joined or "/"
 
 
-def _class_prefixes(declaration: Node, source: bytes) -> Tuple[List[str], bool]:
-    """The prefixes a controller's own @RequestMapping contributes.
+def _class_mapping(declaration: Node, source: bytes) -> Optional[Dict]:
+    """A class or interface level @RequestMapping, or None when there is none.
 
-    Several of them fan the whole controller out, one endpoint per prefix.
+    Several prefixes fan the whole controller out, one endpoint per prefix.
     """
     annotation = _annotation_by_name(declaration, source, REQUEST_MAPPING)
     if annotation is None:
-        return [""], True
-    return _annotation_paths(annotation, source)
+        return None
+    prefixes, readable = _annotation_paths(annotation, source)
+    return {
+        "prefixes": prefixes,
+        "conditions": _mapping_conditions(annotation, source),
+        "readable": readable,
+    }
+
+
+def _method_mapping(annotation: Node, annotation_name: str, source: bytes) -> Dict:
+    """The routes, verbs and conditions one method level mapping declares."""
+    paths, readable = _annotation_paths(annotation, source)
+    verbs: List[str] = []
+    if annotation_name != REQUEST_MAPPING:
+        verbs = [VERB_ANNOTATIONS[annotation_name]]
+    elif readable:
+        # Only asked once the paths are readable, so an endpoint that is
+        # dropped anyway is not also counted as an assumed GET.
+        verbs, readable = _request_mapping_verbs(annotation, source)
+    return {
+        "paths": paths,
+        "verbs": verbs,
+        "conditions": _mapping_conditions(annotation, source),
+        "readable": readable,
+    }
 
 
 def _class_methods(declaration: Node) -> List[Node]:
@@ -274,10 +368,36 @@ def _class_methods(declaration: Node) -> List[Node]:
     return [child for child in body.children if child.type == "method_declaration"]
 
 
+def _method_arity(method: Node) -> int:
+    parameters = method.child_by_field_name("parameters")
+    if parameters is None:
+        return 0
+    return sum(
+        1
+        for child in parameters.children
+        if child.type in {"formal_parameter", "spread_parameter"}
+    )
+
+
+def _declared_name(declaration: Node, source: bytes) -> str:
+    name_node = declaration.child_by_field_name("name")
+    return _node_text(source, name_node) if name_node else "<anonymous>"
+
+
+def _method_key(method: Node, source: bytes) -> Tuple[str, int]:
+    """What matches an override to the interface method it implements."""
+    return _declared_name(method, source), _method_arity(method)
+
+
 def _build_endpoint_entry(
-    route: str, http_method: str, name: str, declaration: Node, file_path: Path
+    route: str,
+    http_method: str,
+    name: str,
+    declaration: Node,
+    file_path: Path,
+    conditions: Dict[str, List[str]],
 ) -> Dict:
-    return {
+    entry = {
         "type": "function",
         "method": http_method,
         "route": route,
@@ -288,42 +408,220 @@ def _build_endpoint_entry(
         "end_line": declaration.end_point[0] + 1,
         "file_path": str(file_path),
     }
+    if conditions:
+        entry["conditions"] = conditions
+    return entry
 
 
 def _endpoints_of_class(
-    declaration: Node, source: bytes, file_path: Path
+    declaration: Node, source: bytes, file_path: Path, inherited: Dict
 ) -> List[Dict]:
-    prefixes, readable = _class_prefixes(declaration, source)
-    if not readable:
+    # An API first controller declares nothing itself: the interface it
+    # implements carries the prefix and the mappings, and the class holds the
+    # body worth documenting, so the implementation is what is emitted.
+    class_mapping = _class_mapping(declaration, source) or inherited.get("class_mapping")
+    if class_mapping and not class_mapping["readable"]:
         _EXTRACTION_DROPS["unresolved"] += 1
         return []
+    prefixes = class_mapping["prefixes"] if class_mapping else [""]
+    class_conditions = class_mapping["conditions"] if class_mapping else {}
+    inherited_methods = inherited.get("methods") or {}
 
     endpoints: List[Dict] = []
     for method in _class_methods(declaration):
         annotation, annotation_name = _mapping_annotation(method, source)
-        if annotation is None:
-            continue
-        paths, path_readable = _annotation_paths(annotation, source)
-        if not path_readable:
+        if annotation is not None:
+            # A method that declares its own mapping overrides the interface's.
+            mapping = _method_mapping(annotation, annotation_name, source)
+        else:
+            mapping = inherited_methods.get(_method_key(method, source))
+            if mapping is None:
+                continue
+        if not mapping["readable"]:
             _EXTRACTION_DROPS["unresolved"] += 1
             continue
-        if annotation_name == REQUEST_MAPPING:
-            verbs, verbs_readable = _request_mapping_verbs(annotation, source)
-            if not verbs_readable:
-                _EXTRACTION_DROPS["unresolved"] += 1
-                continue
-        else:
-            verbs = [VERB_ANNOTATIONS[annotation_name]]
-        name_node = method.child_by_field_name("name")
-        name = _node_text(source, name_node) if name_node else "<anonymous>"
+        conditions = _compose_conditions(class_conditions, mapping["conditions"])
+        name = _declared_name(method, source)
         for prefix in prefixes:
-            for path in paths:
+            for path in mapping["paths"]:
                 route = _join_paths(prefix, path)
-                for verb in verbs:
+                for verb in mapping["verbs"]:
                     endpoints.append(
-                        _build_endpoint_entry(route, verb, name, method, file_path)
+                        _build_endpoint_entry(
+                            route, verb, name, method, file_path, conditions
+                        )
                     )
     return endpoints
+
+
+def _package_name(root: Node, source: bytes) -> str:
+    for child in root.children:
+        if child.type != "package_declaration":
+            continue
+        text = _node_text(source, child).strip().rstrip(";").strip()
+        return text[len("package") :].strip()
+    return ""
+
+
+def _imported_types(root: Node, source: bytes) -> Dict[str, str]:
+    """Simple type name -> the qualified name this file imported it under."""
+    types: Dict[str, str] = {}
+    for child in root.children:
+        if child.type != "import_declaration":
+            continue
+        text = _node_text(source, child).strip().rstrip(";").strip()
+        text = text[len("import") :].strip()
+        if text.startswith("static") or text.endswith(".*"):
+            continue
+        types[text.split(".")[-1]] = text
+    return types
+
+
+def _implemented_names(declaration: Node, source: bytes) -> List[str]:
+    """The interfaces an implements clause names, generic arguments stripped."""
+    interfaces = declaration.child_by_field_name("interfaces")
+    if interfaces is None:
+        return []
+    names: List[str] = []
+    for child in interfaces.children:
+        if child.type != "type_list":
+            continue
+        for entry in child.children:
+            if entry.is_named:
+                names.append(_node_text(source, entry).split("<")[0].strip())
+    return names
+
+
+def _interface_entry(
+    declaration: Node, source: bytes, package: str, file_path: Path
+) -> Optional[Dict]:
+    """One scanned interface's mappings, or None when it declares none."""
+    class_mapping = _class_mapping(declaration, source)
+    methods: Dict[Tuple[str, int], Dict] = {}
+    for method in _class_methods(declaration):
+        annotation, annotation_name = _mapping_annotation(method, source)
+        if annotation is None:
+            continue
+        methods[_method_key(method, source)] = _method_mapping(
+            annotation, annotation_name, source
+        )
+    if class_mapping is None and not methods:
+        return None
+    name = _declared_name(declaration, source)
+    return {
+        "name": name,
+        "package": package,
+        "fqn": f"{package}.{name}" if package else name,
+        "file_path": str(file_path),
+        "class_mapping": class_mapping,
+        "methods": methods,
+        "implemented": False,
+    }
+
+
+def _index_file_types(file_path: str, index: Dict) -> None:
+    """This file's mapping interfaces, and the interfaces its controllers claim."""
+    path = Path(file_path)
+    try:
+        source = path.read_bytes()
+    except OSError:
+        return
+    root = parser.parse(source).root_node
+    package = _package_name(root, source)
+    imported = _imported_types(root, source)
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node.type == "interface_declaration":
+            entry = _interface_entry(node, source, package, path)
+            if entry is not None:
+                index["by_fqn"][entry["fqn"]] = entry
+                index["by_simple"].setdefault(entry["name"], []).append(entry)
+        elif node.type == "class_declaration" and _has_controller_annotation(
+            node, source
+        ):
+            index["implements"].append(
+                (package, imported, _implemented_names(node, source))
+            )
+        stack.extend(list(node.children))
+
+
+def _resolve_interface(
+    name: str, package: str, imported: Dict[str, str], index: Dict
+) -> Optional[Dict]:
+    """The scanned interface an implements clause names.
+
+    Resolution reads the package the way import resolution does: a qualified
+    name is matched whole, a simple one through the file's imports, then its
+    own package, and only then by simple name when the scan set holds exactly
+    one interface with it.
+    """
+    if "." in name:
+        return index["by_fqn"].get(name)
+    qualified = imported.get(name)
+    if qualified:
+        return index["by_fqn"].get(qualified)
+    candidates = index["by_simple"].get(name) or []
+    for candidate in candidates:
+        if candidate["package"] == package:
+            return candidate
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def index_scanned_types(files: Iterable[str], repo_root: str) -> Dict:
+    """The mapping interfaces of the scan set, and which of them are implemented.
+
+    An interface nobody in the scan set implements has no body to document, so
+    it emits nothing and every mapping it declares is counted as dropped.
+    """
+    index: Dict = {"by_fqn": {}, "by_simple": {}, "implements": []}
+    for file_path in files:
+        _index_file_types(file_path, index)
+    for package, imported, names in index["implements"]:
+        for name in names:
+            entry = _resolve_interface(name, package, imported, index)
+            if entry is not None:
+                entry["implemented"] = True
+    for entry in index["by_fqn"].values():
+        if not entry["implemented"]:
+            _EXTRACTION_DROPS["unresolved"] += len(entry["methods"])
+    _TYPE_INDEX_CACHE[repo_root] = index
+    return index
+
+
+def _type_index(repo_root: Optional[str]) -> Dict:
+    """The scan set's interfaces, built on first use and kept for the run."""
+    if not repo_root:
+        return {"by_fqn": {}, "by_simple": {}, "implements": []}
+    cached = _TYPE_INDEX_CACHE.get(repo_root)
+    if cached is not None:
+        return cached
+    return index_scanned_types(find_api_definition_files(repo_root), repo_root)
+
+
+def _inherited_mappings(
+    declaration: Node,
+    source: bytes,
+    package: str,
+    imported: Dict[str, str],
+    index: Dict,
+) -> Dict:
+    """The mappings this controller inherits from the interfaces it implements.
+
+    The first interface that declares a prefix contributes it, and the first
+    that declares a mapping for a method signature contributes that.
+    """
+    class_mapping: Optional[Dict] = None
+    methods: Dict[Tuple[str, int], Dict] = {}
+    for name in _implemented_names(declaration, source):
+        entry = _resolve_interface(name, package, imported, index)
+        if entry is None:
+            continue
+        if class_mapping is None:
+            class_mapping = entry["class_mapping"]
+        for key, mapping in entry["methods"].items():
+            methods.setdefault(key, mapping)
+    return {"class_mapping": class_mapping, "methods": methods}
 
 
 def find_api_endpoints(file_path, repo_root: Optional[str] = None) -> List[Dict]:
@@ -334,12 +632,19 @@ def find_api_endpoints(file_path, repo_root: Optional[str] = None) -> List[Dict]
         return []
 
     tree = parser.parse(source)
+    root = tree.root_node
+    index = _type_index(repo_root)
+    package = _package_name(root, source)
+    imported = _imported_types(root, source)
 
     endpoints: List[Dict] = []
-    stack = [tree.root_node]
+    stack = [root]
     while stack:
         node = stack.pop()
-        if node.type in _CLASS_TYPES and _has_controller_annotation(node, source):
-            endpoints.extend(_endpoints_of_class(node, source, path))
+        # Only a class is emitted: an interface holds mappings for whatever
+        # implements it, and emitting both would document the route twice.
+        if node.type == "class_declaration" and _has_controller_annotation(node, source):
+            inherited = _inherited_mappings(node, source, package, imported, index)
+            endpoints.extend(_endpoints_of_class(node, source, path, inherited))
         stack.extend(list(node.children))
     return endpoints

--- a/java_pipeline/run_swagger_generation.py
+++ b/java_pipeline/run_swagger_generation.py
@@ -1,0 +1,849 @@
+import os
+import datetime
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import pipeline_common
+from config import Configurations
+from java_pipeline.definition_swagger_generator import (
+    HANDLER_TOKEN_BUDGET,
+    get_batch_definition_swagger,
+    get_function_definition_swagger,
+    section_token_cost,
+)
+from java_pipeline.find_api_definition_files import find_api_definition_files
+from java_pipeline.generate_file_information import process_file, reset_source_index
+from java_pipeline.identify_api_functions import (
+    find_api_endpoints,
+    extraction_drops,
+    log_extraction_drops,
+    reset_extraction_drops,
+)
+from utils import (
+    get_git_commit_hash,
+    get_github_repo_url,
+    get_repo_path,
+    get_repo_name,
+    get_output_filepath,
+    get_changed_files_since,
+)
+
+config = Configurations()
+
+_EFFECTIVE_CONTEXT_BUDGET = pipeline_common.EFFECTIVE_CONTEXT_BUDGET
+
+_FILE_CONTENT_CACHE: Dict[str, List[str]] = {}
+# File path -> content hash, and file path -> the cache entry holding its
+# metadata. Both are per run: two runs in one process are two checkouts.
+_CONTENT_HASHES: Dict[str, Optional[str]] = {}
+_METADATA_ENTRIES: Dict[str, str] = {}
+
+
+def should_process_directory(dir_path: str, repo_root: str) -> bool:
+    # Only components below the scanned repo may be ignored, otherwise a repo
+    # living under /var, /tmp or /build processes nothing.
+    path_parts = os.path.relpath(dir_path, repo_root).split(os.sep)
+    return not any(part in config.ignored_dirs for part in path_parts)
+
+
+def _api_index_output_path() -> str:
+    return pipeline_common.api_index_output_path(get_output_filepath())
+
+
+# Per file metadata is cached under the output directory, never inside the
+# scanned repo: a run must not create or delete anything in the user's tree.
+METADATA_CACHE_PIPELINE = "java"
+
+# Bumped when the shape of a metadata entry changes. A missing or stale marker
+# wipes this pipeline's cache before anything reads it.
+METADATA_CACHE_VERSION = "1"
+
+
+def _metadata_cache_dir() -> str:
+    return pipeline_common.metadata_cache_dir(
+        get_output_filepath(), METADATA_CACHE_PIPELINE
+    )
+
+
+def _content_hash(file_path: str) -> Optional[str]:
+    return pipeline_common.content_hash(file_path, _CONTENT_HASHES)
+
+
+def _metadata_cache_filename(file_path: str, content_hash: str) -> str:
+    return pipeline_common.metadata_cache_filename(file_path, content_hash)
+
+
+def _metadata_cache_path(file_path: str) -> Optional[str]:
+    """Where this file's metadata sits for the content it holds right now."""
+    return pipeline_common.metadata_cache_path(
+        file_path, _metadata_cache_dir, _content_hash(file_path)
+    )
+
+
+def _prepare_metadata_cache() -> str:
+    return pipeline_common.prepare_metadata_cache(
+        _metadata_cache_dir(), METADATA_CACHE_VERSION
+    )
+
+
+def _cache_file_metadata(file_path: str, directory_path: str) -> None:
+    pipeline_common.cache_file_metadata(
+        file_path,
+        directory_path,
+        _metadata_cache_path,
+        process_file,
+        _METADATA_ENTRIES,
+        on_error=lambda path, exc: print(
+            f"apimesh: skipping metadata for {path}: {exc}"
+        ),
+    )
+
+
+def _build_metadata_cache(directory_path: str) -> None:
+    """One cache entry per java file below the repo root."""
+    pipeline_common.build_metadata_cache(
+        directory_path,
+        _prepare_metadata_cache,
+        should_process_directory,
+        lambda file_path: file_path.endswith(".java"),
+        _cache_file_metadata,
+    )
+
+
+def _prune_metadata_cache() -> None:
+    pipeline_common.prune_metadata_cache(_metadata_cache_dir(), _METADATA_ENTRIES)
+
+
+def _load_file_metadata(file_path: str):
+    return pipeline_common.load_file_metadata(_metadata_cache_path(file_path))
+
+
+def _normalize_route(route) -> str:
+    """
+    Canonical path for a route the extractor found. Spring already writes its
+    path variables as {id}, so there is nothing to rewrite: the swagger key, the
+    api_index key and the removal lookup only need one leading slash and no
+    doubled separators to stay matched across runs.
+    """
+    if not route or not isinstance(route, str):
+        return ""
+    normalized = route.strip()
+    if not normalized.startswith("/"):
+        normalized = f"/{normalized}"
+    while "//" in normalized:
+        normalized = normalized.replace("//", "/")
+    return normalized
+
+
+def _endpoint_key(route, method):
+    return pipeline_common.endpoint_key(route, method, _normalize_route)
+
+
+def _job_method(endpoint):
+    return endpoint.get("method") or endpoint.get("http_method")
+
+
+def _imported_symbol_names(import_item) -> List[str]:
+    """The types the handler actually reached for through this import.
+
+    A wildcard import binds a whole package, so the usage sites are what says
+    which of its types this handler needs.
+    """
+    used = [name for name in import_item.get("used_names") or [] if name]
+    if used:
+        return used
+    imported_name = import_item.get("imported_name")
+    if not imported_name or imported_name == "*":
+        return []
+    return [imported_name]
+
+
+def _origin_paths(origin: str) -> List[str]:
+    """The java files an import origin covers: a package directory or one file."""
+    if os.path.isdir(origin):
+        return [
+            os.path.join(origin, name)
+            for name in sorted(os.listdir(origin))
+            if name.endswith(".java")
+        ]
+    return [origin] if origin.endswith(".java") else []
+
+
+def _resolve_imported_definitions(import_item, route):
+    origin = import_item.get("origin")
+    if not origin:
+        return []
+    name_candidates = _imported_symbol_names(import_item)
+    if not name_candidates:
+        return []
+
+    found: Dict[str, Dict] = {}
+    for origin_path in _origin_paths(origin):
+        if len(found) == len(name_candidates):
+            break
+        metadata = _load_file_metadata(origin_path)
+        if not metadata:
+            continue
+        elements = metadata.get("elements", {})
+        for key in ("classes", "functions", "variables"):
+            for item in elements.get(key, []):
+                name = item.get("name")
+                if name not in name_candidates or name in found:
+                    continue
+                start_line = item.get("start_line")
+                end_line = item.get("end_line")
+                if not isinstance(start_line, int) or not isinstance(end_line, int):
+                    continue
+                found[name] = {
+                    "type": item.get("type") or key[:-1],
+                    "name": name,
+                    "start_line": start_line,
+                    "end_line": end_line,
+                    "route": route,
+                    "file_path": origin_path,
+                }
+    return list(found.values())
+
+
+def _endpoint_imports(endpoint, abs_file_path, route):
+    return pipeline_common.endpoint_imports(
+        endpoint,
+        abs_file_path,
+        route,
+        _load_file_metadata,
+        get_dependencies,
+        _resolve_imported_definitions,
+    )
+
+
+def _build_api_index(endpoints: list) -> dict:
+    return pipeline_common.build_api_index(
+        endpoints, _endpoint_key, _job_method, _endpoint_imports
+    )
+
+
+def _write_api_index(api_index: dict) -> None:
+    pipeline_common.write_api_index(api_index, _api_index_output_path())
+
+
+def _load_existing_swagger():
+    return pipeline_common.load_existing_swagger(get_output_filepath(), _normalize_route)
+
+
+def _load_existing_api_index():
+    return pipeline_common.load_existing_api_index(
+        _api_index_output_path(), _endpoint_key
+    )
+
+
+def _remove_endpoint_from_swagger(swagger: dict, key: str) -> None:
+    pipeline_common.remove_endpoint_from_swagger(swagger, key, _normalize_route)
+
+
+def _normalize_swagger_fragment(
+    fragment, route: str, http_method: Optional[str]
+) -> Optional[Dict]:
+    """Re-key an LLM fragment under the route and method the extractor found.
+
+    The model happily rewrites paths, which would diverge from the api_index
+    keys and make incremental removal impossible, so only the first operation
+    body is kept and re-keyed.
+    """
+    route_key = _normalize_route(route)
+    if not route_key:
+        return None
+    _, operation = pipeline_common.first_operation(fragment)
+    if operation is None:
+        return None
+    return {
+        route_key: {
+            (http_method or "GET").lower(): pipeline_common.normalize_operation_fields(
+                operation
+            )
+        }
+    }
+
+
+def _generate_swagger_fragment(directory_path: str, method_info: Dict) -> Dict:
+    context_blocks, method_definition = provide_context_codeblock(
+        directory_path, method_info
+    )
+    http_method = _job_method(method_info) or "GET"
+    context_blocks = [[f"HTTP_METHOD: {http_method}\n"]] + context_blocks
+    handler_name = method_info.get("name")
+    if handler_name:
+        context_blocks = [[f"HANDLER: {handler_name}\n"]] + context_blocks
+    return get_function_definition_swagger(
+        method_definition,
+        context_blocks,
+        method_info["route"],
+        http_method,
+        source_file=method_info.get("file_path"),
+    )
+
+
+def _swagger_fragment_for_endpoint(directory_path: str, method_info: Dict) -> Optional[Dict]:
+    """One endpoint's swagger fragment, or None when it could not be generated."""
+    route = method_info.get("route")
+    http_method = _job_method(method_info) or "GET"
+    if not route:
+        return None
+    try:
+        raw_fragment = _generate_swagger_fragment(directory_path, method_info)
+    except Exception as exc:
+        print(f"apimesh: skipped {http_method} {route}: {exc}")
+        return None
+    normalized = _normalize_swagger_fragment(raw_fragment, route, http_method)
+    if normalized is None:
+        print(
+            f"apimesh: skipped {http_method} {route}: "
+            "response had no usable swagger paths"
+        )
+        return None
+    # The fallback stores the batch-shaped hash, not the hash of its own prompt:
+    # the next run recomputes the batch shape, and a hash it can never match
+    # would make this endpoint regenerate forever.
+    context_hash = _endpoint_context_hash(directory_path, method_info)
+    if context_hash:
+        method_info["context_hash"] = context_hash
+    return normalized
+
+
+def _update_swagger_for_endpoints(
+    swagger: dict, directory_path: str, endpoints: list
+) -> Tuple[List[Dict], List[Dict]]:
+    """Generate every endpoint behind its own error boundary.
+
+    One failing LLM call used to abort the whole incremental run, which dropped
+    the CLI into its slow legacy fallback.
+    """
+    generated: List[Dict] = []
+    failed: List[Dict] = []
+    for method_info in endpoints:
+        normalized = _swagger_fragment_for_endpoint(directory_path, method_info)
+        if normalized is None:
+            failed.append(method_info)
+            continue
+        pipeline_common.merge_paths(swagger, {"paths": normalized})
+        generated.append(method_info)
+    return generated, failed
+
+
+def _handler_lines(job: Dict) -> List[str]:
+    """The handler's own source lines, read for pricing its batch section."""
+    lines = _read_file_lines(job.get("file_path") or "") or []
+    start_line = job.get("start_line") or 1
+    end_line = job.get("end_line") or start_line
+    return lines[start_line - 1 : end_line]
+
+
+def _batch_section_tokens(job: Dict) -> int:
+    """What this endpoint's section costs the batch."""
+    return section_token_cost(_batch_label(job), "".join(_handler_lines(job)))
+
+
+def _batch_endpoint_jobs(endpoint_jobs: List[Dict]) -> List[List[Dict]]:
+    """Endpoint jobs grouped by source file, packed to fit the context budget.
+
+    Capping each handler on its own still let ten of them add up to far more
+    than the whole prompt can carry, so a batch is closed as soon as the next
+    section would push its sections past the budget. Ten endpoints stays the
+    secondary limit.
+    """
+    batches: List[List[Dict]] = []
+    for jobs in pipeline_common.group_jobs_by_file(endpoint_jobs).values():
+        batches.extend(
+            pipeline_common.pack_batches(
+                jobs,
+                _batch_section_tokens,
+                pipeline_common.MAX_ENDPOINTS_PER_BATCH,
+                _EFFECTIVE_CONTEXT_BUDGET,
+            )
+        )
+    return batches
+
+
+def _batch_source_file(batch: List[Dict]) -> str:
+    if not batch:
+        return "unknown file"
+    return batch[0].get("file_path") or "unknown file"
+
+
+def _batch_label(job: Dict) -> str:
+    """The METHOD PATH line the model is asked to echo back as its key."""
+    method = (_job_method(job) or "GET").upper()
+    return f"{method} {_normalize_route(job.get('route'))}"
+
+
+def _batch_entry(directory_path: str, job: Dict) -> Tuple[str, List[str], List[List[str]]]:
+    """One endpoint's prompt material: its label, its handler body, its context."""
+    blocks, method_definition = provide_context_codeblock(directory_path, job)
+    return _batch_label(job), method_definition, blocks
+
+
+def _context_hash(context_blocks, method_definition) -> str:
+    """The one context hash recipe every pipeline shares."""
+    return pipeline_common.context_hash(
+        context_blocks, method_definition, HANDLER_TOKEN_BUDGET
+    )
+
+
+def _endpoint_context_hash(directory_path: str, job: Dict) -> Optional[str]:
+    """This endpoint's context hash, or None when its source cannot be read."""
+    try:
+        _, body, blocks = _batch_entry(directory_path, job)
+    except Exception:
+        return None
+    return _context_hash(blocks, body)
+
+
+def _generate_batch_payload(directory_path: str, batch: List[Dict]) -> Optional[Dict]:
+    """One LLM call for a file's endpoints. Returns the model's raw payload."""
+    entries: List[Tuple[str, str]] = []
+    context_blocks: List[List[str]] = []
+    for job in batch:
+        label, body, blocks = _batch_entry(directory_path, job)
+        job["context_hash"] = _context_hash(blocks, body)
+        entries.append((label, "".join(body)))
+        context_blocks.extend(blocks)
+    return get_batch_definition_swagger(
+        entries, context_blocks, _batch_source_file(batch)
+    )
+
+
+def _operation_from_batch(
+    payload, route: str, http_method: Optional[str]
+) -> Optional[Dict]:
+    """The operation the model returned for one requested endpoint.
+
+    The model rewrites paths, so both sides are normalized before they are
+    compared, and the result is re-keyed under the extractor's route exactly as
+    the per-endpoint path does.
+    """
+    if not isinstance(payload, dict):
+        return None
+    paths = payload.get("paths")
+    if not isinstance(paths, dict):
+        return None
+    route_key = _normalize_route(route)
+    if not route_key:
+        return None
+    method_key = (http_method or "GET").lower()
+    for model_route, path_item in paths.items():
+        if not isinstance(path_item, dict):
+            continue
+        if _normalize_route(model_route) != route_key:
+            continue
+        for name, value in path_item.items():
+            if str(name).lower() == method_key and isinstance(value, dict):
+                return {
+                    route_key: {
+                        method_key: pipeline_common.normalize_operation_fields(value)
+                    }
+                }
+    return None
+
+
+def _apply_batch_payload(
+    swagger: dict, directory_path: str, batch: List[Dict], payload
+) -> Tuple[List[Dict], List[Dict]]:
+    """Merge a batch reply, falling back to per-endpoint calls when it is unusable.
+
+    An endpoint the model simply left out stays failed, so it is kept out of the
+    api_index and retried next run.
+    """
+    if not isinstance(payload, dict) or not isinstance(payload.get("paths"), dict):
+        print(
+            f"apimesh: batch reply unusable for {_batch_source_file(batch)}, "
+            "documenting its endpoints one by one"
+        )
+        return _update_swagger_for_endpoints(swagger, directory_path, batch)
+    generated: List[Dict] = []
+    failed: List[Dict] = []
+    for job in batch:
+        route = job.get("route")
+        http_method = _job_method(job) or "GET"
+        normalized = _operation_from_batch(payload, route, http_method)
+        if normalized is None:
+            failed.append(job)
+            print(
+                f"apimesh: skipped {http_method} {route}: "
+                "missing from the batch reply"
+            )
+            continue
+        pipeline_common.merge_paths(swagger, {"paths": normalized})
+        generated.append(job)
+    return generated, failed
+
+
+def _update_swagger_for_batches(
+    swagger: dict, directory_path: str, endpoint_jobs: list
+) -> Tuple[List[Dict], List[Dict]]:
+    """Every endpoint of every batch, behind the batch's own error boundary."""
+    generated: List[Dict] = []
+    failed: List[Dict] = []
+    for batch in _batch_endpoint_jobs(endpoint_jobs):
+        try:
+            payload = _generate_batch_payload(directory_path, batch)
+        except Exception as exc:
+            print(f"apimesh: batch failed for {_batch_source_file(batch)}: {exc}")
+            payload = None
+        batch_generated, batch_failed = _apply_batch_payload(
+            swagger, directory_path, batch, payload
+        )
+        generated.extend(batch_generated)
+        failed.extend(batch_failed)
+    return generated, failed
+
+
+def _report_generation(generated: int, failed: int) -> None:
+    """Raising on a total wipeout lets the CLI fall back to the generic extractor."""
+    total = generated + failed
+    if not total:
+        return
+    print(f"generated {generated} of {total} endpoints ({failed} failed)")
+    if generated == 0:
+        raise RuntimeError("java swagger generation produced no endpoints")
+
+
+def _unchanged_context_keys(
+    directory_path: str, keys, endpoint_map: Dict, existing_index: Dict
+) -> set:
+    """The dirty keys whose prompt text is what they were generated from.
+
+    Their stored spec operation and index entry are already correct, so they
+    cost no LLM call. This is what makes the dependency hop cheap: an edit in
+    an imported file that never reaches the endpoint's own context lands here.
+    """
+    unchanged = set()
+    for key in keys:
+        stored = pipeline_common.stored_context_hash(existing_index.get(key))
+        if not stored:
+            continue
+        jobs = endpoint_map.get(key) or []
+        # One hash is stored per key, so a key several jobs share has nothing
+        # to compare against and is regenerated.
+        if len(jobs) != 1:
+            continue
+        if _endpoint_context_hash(directory_path, jobs[0]) == stored:
+            unchanged.add(key)
+    return unchanged
+
+
+def _maybe_incremental_update(
+    directory_path: str, endpoint_jobs: list, host: Optional[str] = None
+):
+    existing_swagger = _load_existing_swagger()
+    existing_index = _load_existing_api_index()
+    if not existing_swagger or not isinstance(existing_index, dict):
+        return None
+    base_commit = pipeline_common.base_commit_of(existing_swagger)
+    if not base_commit:
+        return None
+    changed_files = get_changed_files_since(base_commit, directory_path, include_uncommitted=True)
+    if changed_files is None:
+        return None
+    endpoint_map = pipeline_common.group_endpoints(
+        endpoint_jobs, _endpoint_key, _job_method
+    )
+    existing_keys = set(existing_index.keys())
+    new_keys = set(endpoint_map.keys())
+    removed_keys = existing_keys - new_keys
+    added_keys = new_keys - existing_keys
+    # An endpoint that failed last run is absent from the index, so it reads as
+    # added and still has to be generated when git reports nothing changed.
+    if (
+        not changed_files
+        and not added_keys
+        and not removed_keys
+        and pipeline_common.index_paths_exist(existing_index)
+    ):
+        pipeline_common.record_coverage(existing_swagger, len(endpoint_jobs), 0, len(endpoint_jobs), 0)
+        return pipeline_common.apply_host(existing_swagger, host)
+    changed_keys = set()
+    for key in existing_keys & new_keys:
+        if pipeline_common.endpoint_has_changed(
+            existing_index.get(key), endpoint_map.get(key), changed_files
+        ):
+            changed_keys.add(key)
+
+    keys_to_update = added_keys | changed_keys
+    if pipeline_common.should_regenerate_fully(keys_to_update, new_keys):
+        return None
+
+    unchanged_keys = _unchanged_context_keys(
+        directory_path, keys_to_update, endpoint_map, existing_index
+    )
+    if unchanged_keys:
+        keys_to_update -= unchanged_keys
+        print(
+            f"apimesh: skipped {len(unchanged_keys)} unchanged endpoints "
+            "(context hash match)"
+        )
+
+    updated_index = dict(existing_index)
+
+    for key in removed_keys:
+        updated_index.pop(key, None)
+        _remove_endpoint_from_swagger(existing_swagger, key)
+
+    pipeline_common.rebuild_unchanged_index_entries(
+        unchanged_keys, endpoint_map, existing_index, updated_index, _build_api_index
+    )
+
+    jobs_to_update: List[Dict] = []
+    for key in keys_to_update:
+        jobs_to_update.extend(endpoint_map.get(key, []))
+    generated, failed = _update_swagger_for_batches(
+        existing_swagger, directory_path, jobs_to_update
+    )
+    failed_keys = {_endpoint_key(job.get("route"), _job_method(job)) for job in failed}
+    # A failed endpoint keeps whatever the index already held (or stays out of
+    # it) so the next run still sees it as new or stale and retries.
+    pipeline_common.apply_generated_index_entries(
+        updated_index, _build_api_index(generated), failed_keys
+    )
+
+    # The incremental pass never raises: the existing spec is still valid, and
+    # persisting the index below (failed keys dropped) is what schedules the
+    # retry. Raising here would discard both and launch the slow fallback.
+    total = len(generated) + len(failed)
+    if total:
+        print(f"generated {len(generated)} of {total} endpoints ({len(failed)} failed)")
+    if failed and not generated:
+        print("apimesh: every changed endpoint failed; keeping the previous spec, they will retry next run")
+
+    pipeline_common.stamp_commit_reference(existing_swagger, get_git_commit_hash())
+    _write_api_index(updated_index)
+    pipeline_common.record_coverage(
+        existing_swagger,
+        len(endpoint_jobs),
+        len(generated),
+        max(len(endpoint_jobs) - len(generated) - len(failed), 0),
+        len(failed),
+    )
+    return pipeline_common.apply_host(existing_swagger, host)
+
+
+def _reset_caches() -> None:
+    """Drop everything held between runs.
+
+    Two runs in one process see two checkouts, so a cached file body or import
+    origin from the first would be read as the second's.
+    """
+    _FILE_CONTENT_CACHE.clear()
+    _CONTENT_HASHES.clear()
+    _METADATA_ENTRIES.clear()
+    reset_source_index()
+
+
+def _read_file_lines(file_path: str) -> Optional[List[str]]:
+    cached = _FILE_CONTENT_CACHE.get(file_path)
+    if cached is not None:
+        return cached
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="replace") as handle:
+            lines = handle.readlines()
+    except OSError:
+        return None
+    _FILE_CONTENT_CACHE[file_path] = lines
+    return lines
+
+
+def get_dependencies(
+    data: Dict, start_line: int, end_line: int, file_path: str
+) -> Tuple[List[Dict], List[Dict]]:
+    existing_function_names = [
+        item.get("name") for item in data.get("elements", {}).get("functions", [])
+    ]
+    in_file_dependency_functions: List[Dict] = []
+    for call in data.get("elements", {}).get("function_calls", []):
+        call_name = call.get("name")
+        call_start = call.get("start_line")
+        call_end = call.get("end_line")
+        if (
+            call_name in existing_function_names
+            and isinstance(call_start, int)
+            and isinstance(call_end, int)
+            and start_line <= call_start <= end_line
+        ):
+            entry = call.copy()
+            entry["file_path"] = file_path
+            in_file_dependency_functions.append(entry)
+
+    imported_functions: List[Dict] = []
+    for item in data.get("imports", []):
+        # An import counts for every handler of the file, not only the ones
+        # whose own lines name it. A Spring controller injects its
+        # collaborators as fields and constructor parameters, so the type name
+        # is written once, far above the handler; scoping imports to the
+        # handler's line range recorded no dependency at all and the model saw
+        # none of the services and DTOs the endpoint runs on.
+        if not item.get("usage_lines"):
+            continue
+        entry = dict(item)
+        # Only the types the file reached for, so a wildcard import does not
+        # drag a whole package into the prompt.
+        entry["used_names"] = sorted(
+            {
+                usage.get("name")
+                for usage in item.get("usages", [])
+                if usage.get("name")
+            }
+        )
+        imported_functions.append(entry)
+    return in_file_dependency_functions, imported_functions
+
+
+def get_code_blocks(
+    in_file_dependency_functions: List[Dict],
+    imported_functions: List[Dict],
+    file_name: str,
+    directory_path: str,
+) -> List[List[str]]:
+    code_blocks: List[List[str]] = []
+    lines = _read_file_lines(file_name) or []
+    for block in in_file_dependency_functions:
+        start = block.get("function_start_line") or block.get("start_line")
+        end = block.get("function_end_line") or block.get("end_line")
+        if not isinstance(start, int) or not isinstance(end, int):
+            continue
+        segment = lines[start - 1 : end]
+        if segment:
+            code_blocks.append(segment)
+
+    for imp in imported_functions:
+        for definition in _resolve_imported_definitions(imp, None):
+            origin_lines = _read_file_lines(definition["file_path"]) or []
+            snippet = origin_lines[definition["start_line"] - 1 : definition["end_line"]]
+            if snippet:
+                code_blocks.append(snippet)
+    return code_blocks
+
+
+def provide_context_codeblock(directory_path: str, method_info: Dict):
+    file_name = method_info["file_path"]
+    lines = _read_file_lines(file_name) or []
+    start_line = method_info.get("start_line", 1)
+    end_line = method_info.get("end_line", start_line)
+    method_definition_code_block = lines[start_line - 1 : end_line]
+
+    data = _load_file_metadata(file_name) or {
+        "elements": {"functions": [], "function_calls": []},
+        "imports": [],
+    }
+
+    in_file_dependency_functions, imported_functions = get_dependencies(
+        data, start_line, end_line, file_name
+    )
+    context_code_blocks = get_code_blocks(
+        in_file_dependency_functions, imported_functions, file_name, directory_path
+    )
+    return context_code_blocks, method_definition_code_block
+
+
+def _dedupe_endpoint_jobs(endpoint_jobs: List[Dict]) -> List[Dict]:
+    """One job per route and method.
+
+    The same route registered twice, or reached through two class prefixes that
+    collapse to one path, used to cost two LLM calls and write the second
+    answer over the first.
+    """
+    seen = set()
+    unique: List[Dict] = []
+    for job in endpoint_jobs:
+        if not job.get("route"):
+            continue
+        key = _endpoint_key(job.get("route"), _job_method(job))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(job)
+    return unique
+
+
+def run_swagger_generation(host: str) -> Optional[Dict]:
+    _reset_caches()
+    directory_path = get_repo_path()
+    repo_name = get_repo_name()
+    # Built before the try: a walk that dies leaves an incomplete picture of
+    # which entries are still live, and pruning against it would be wrong.
+    _build_metadata_cache(directory_path)
+
+    try:
+        api_files = find_api_definition_files(directory_path)
+        endpoints: List[Dict] = []
+        reset_extraction_drops()
+        for file in api_files:
+            endpoints.extend(find_api_endpoints(Path(file), directory_path))
+        log_extraction_drops()
+
+        endpoint_jobs = _dedupe_endpoint_jobs(endpoints)
+
+        # Nothing was extracted: hand back None so the caller falls back instead
+        # of publishing an empty spec (or, worse, incrementally deleting one).
+        if not endpoint_jobs:
+            print(
+                "apimesh: java parser found 0 endpoints, "
+                "falling back to generic extraction"
+            )
+            return None
+
+        incremental_swagger = _maybe_incremental_update(directory_path, endpoint_jobs, host)
+        if incremental_swagger is not None:
+            return incremental_swagger
+
+        swagger = {
+            "openapi": "3.0.0",
+            "info": {
+                "title": repo_name,
+                "version": "1.0.0",
+                "description": "This Swagger file was generated using OpenAI GPT.",
+                "x-generated-at": datetime.datetime.utcnow().isoformat() + "Z",
+                "x-commit-reference": get_git_commit_hash(),
+                "x-github-repo-url": get_github_repo_url(),
+            },
+            "servers": [{"url": host}],
+            "paths": {},
+        }
+
+        generated: List[Dict] = []
+        failed: List[Dict] = []
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            futures = {
+                executor.submit(_generate_batch_payload, directory_path, batch): batch
+                for batch in _batch_endpoint_jobs(endpoint_jobs)
+            }
+            for future in as_completed(futures):
+                batch = futures[future]
+                try:
+                    payload = future.result()
+                except Exception as exc:
+                    print(
+                        f"apimesh: batch failed for {_batch_source_file(batch)}: {exc}"
+                    )
+                    payload = None
+                batch_generated, batch_failed = _apply_batch_payload(
+                    swagger, directory_path, batch, payload
+                )
+                generated.extend(batch_generated)
+                failed.extend(batch_failed)
+
+        _report_generation(len(generated), len(failed))
+
+        # Only endpoints that made it into the spec are indexed, otherwise a
+        # failure looks unchanged next run and is never retried.
+        _write_api_index(_build_api_index(generated))
+        pipeline_common.record_coverage(
+            swagger, len(endpoint_jobs), len(generated), 0, len(failed),
+            # Only the mappings extraction could not read are dropped routes;
+            # a @RequestMapping documented as GET is an assumption, not a loss.
+            dropped=extraction_drops().get("unresolved", 0),
+        )
+
+        return swagger
+    finally:
+        # The cache outlives the run; only entries for content that is gone are
+        # dropped, so the next run parses just what changed.
+        _prune_metadata_cache()

--- a/java_pipeline/run_swagger_generation.py
+++ b/java_pipeline/run_swagger_generation.py
@@ -17,8 +17,10 @@ from java_pipeline.generate_file_information import process_file, reset_source_i
 from java_pipeline.identify_api_functions import (
     find_api_endpoints,
     extraction_drops,
+    index_scanned_types,
     log_extraction_drops,
     reset_extraction_drops,
+    reset_type_index,
 )
 from utils import (
     get_git_commit_hash,
@@ -144,6 +146,25 @@ def _job_method(endpoint):
     return endpoint.get("method") or endpoint.get("http_method")
 
 
+# The mapping conditions the prompt reports, in the order it reports them.
+_CONDITION_ORDER = ("consumes", "produces", "params", "headers")
+
+
+def _job_variants(job: Dict) -> List[Dict]:
+    """The handlers one job documents: itself, plus the variants merged onto it."""
+    return [job] + list(job.get("variants") or [])
+
+
+def _conditions_note(job: Dict) -> str:
+    """The one line telling the model what narrows this mapping."""
+    conditions = job.get("conditions") or {}
+    return ", ".join(
+        f"{name}={', '.join(conditions[name])}"
+        for name in _CONDITION_ORDER
+        if conditions.get(name)
+    )
+
+
 def _imported_symbol_names(import_item) -> List[str]:
     """The types the handler actually reached for through this import.
 
@@ -217,9 +238,25 @@ def _endpoint_imports(endpoint, abs_file_path, route):
     )
 
 
+def _indexed_endpoints(endpoints: list) -> list:
+    """Every merged variant, so an edit to any of their files dirties the key."""
+    indexed = []
+    for job in endpoints:
+        context_hash = job.get("context_hash")
+        for variant in _job_variants(job):
+            if variant is job:
+                indexed.append(job)
+                continue
+            entry = dict(variant)
+            if context_hash:
+                entry["context_hash"] = context_hash
+            indexed.append(entry)
+    return indexed
+
+
 def _build_api_index(endpoints: list) -> dict:
     return pipeline_common.build_api_index(
-        endpoints, _endpoint_key, _job_method, _endpoint_imports
+        _indexed_endpoints(endpoints), _endpoint_key, _job_method, _endpoint_imports
     )
 
 
@@ -330,12 +367,29 @@ def _update_swagger_for_endpoints(
     return generated, failed
 
 
-def _handler_lines(job: Dict) -> List[str]:
-    """The handler's own source lines, read for pricing its batch section."""
+def _variant_lines(job: Dict) -> List[str]:
+    """One handler's own source lines."""
     lines = _read_file_lines(job.get("file_path") or "") or []
     start_line = job.get("start_line") or 1
     end_line = job.get("end_line") or start_line
     return lines[start_line - 1 : end_line]
+
+
+def _handler_lines(job: Dict) -> List[str]:
+    """The handler source this job's prompt section carries.
+
+    A job that merged content negotiation variants carries all of their bodies,
+    each under the condition that picks it, so the model documents them as the
+    one operation Spring serves them as.
+    """
+    variants = _job_variants(job)
+    lines: List[str] = []
+    for variant in variants:
+        note = _conditions_note(variant)
+        if note or len(variants) > 1:
+            lines.append(f"// Mapping conditions: {note or 'none'}\n")
+        lines.extend(_variant_lines(variant))
+    return lines
 
 
 def _batch_section_tokens(job: Dict) -> int:
@@ -636,6 +690,7 @@ def _reset_caches() -> None:
     _CONTENT_HASHES.clear()
     _METADATA_ENTRIES.clear()
     reset_source_index()
+    reset_type_index()
 
 
 def _read_file_lines(file_path: str) -> Optional[List[str]]:
@@ -723,43 +778,70 @@ def get_code_blocks(
 
 
 def provide_context_codeblock(directory_path: str, method_info: Dict):
-    file_name = method_info["file_path"]
-    lines = _read_file_lines(file_name) or []
-    start_line = method_info.get("start_line", 1)
-    end_line = method_info.get("end_line", start_line)
-    method_definition_code_block = lines[start_line - 1 : end_line]
+    method_definition_code_block = _handler_lines(method_info)
 
-    data = _load_file_metadata(file_name) or {
-        "elements": {"functions": [], "function_calls": []},
-        "imports": [],
-    }
-
-    in_file_dependency_functions, imported_functions = get_dependencies(
-        data, start_line, end_line, file_name
-    )
-    context_code_blocks = get_code_blocks(
-        in_file_dependency_functions, imported_functions, file_name, directory_path
-    )
+    context_code_blocks: List[List[str]] = []
+    # Every merged variant contributes its own dependencies; the duplicates two
+    # variants of one handler share are dropped when the context is fitted.
+    for variant in _job_variants(method_info):
+        file_name = variant["file_path"]
+        start_line = variant.get("start_line", 1)
+        end_line = variant.get("end_line", start_line)
+        data = _load_file_metadata(file_name) or {
+            "elements": {"functions": [], "function_calls": []},
+            "imports": [],
+        }
+        in_file_dependency_functions, imported_functions = get_dependencies(
+            data, start_line, end_line, file_name
+        )
+        context_code_blocks.extend(
+            get_code_blocks(
+                in_file_dependency_functions,
+                imported_functions,
+                file_name,
+                directory_path,
+            )
+        )
     return context_code_blocks, method_definition_code_block
 
 
+def _condition_signature(job: Dict) -> Tuple:
+    """What tells two handlers on one route and verb apart."""
+    conditions = job.get("conditions") or {}
+    return tuple(
+        (name, tuple(conditions.get(name) or ()))
+        for name in _CONDITION_ORDER
+        if conditions.get(name)
+    )
+
+
 def _dedupe_endpoint_jobs(endpoint_jobs: List[Dict]) -> List[Dict]:
-    """One job per route and method.
+    """One job per route and method, content negotiation variants merged.
 
     The same route registered twice, or reached through two class prefixes that
     collapse to one path, used to cost two LLM calls and write the second
-    answer over the first.
+    answer over the first. Two handlers that differ by consumes, produces,
+    params or headers are not that: they are one OpenAPI operation, so they are
+    documented together and the job carries every one of their bodies.
     """
-    seen = set()
+    kept_by_key: Dict[str, Dict] = {}
     unique: List[Dict] = []
     for job in endpoint_jobs:
         if not job.get("route"):
             continue
         key = _endpoint_key(job.get("route"), _job_method(job))
-        if key in seen:
+        kept = kept_by_key.get(key)
+        if kept is None:
+            kept_by_key[key] = job
+            unique.append(job)
             continue
-        seen.add(key)
-        unique.append(job)
+        signature = _condition_signature(job)
+        if any(
+            _condition_signature(variant) == signature
+            for variant in _job_variants(kept)
+        ):
+            continue
+        kept.setdefault("variants", []).append(job)
     return unique
 
 
@@ -775,6 +857,9 @@ def run_swagger_generation(host: str) -> Optional[Dict]:
         api_files = find_api_definition_files(directory_path)
         endpoints: List[Dict] = []
         reset_extraction_drops()
+        # The interfaces the controllers implement are resolved across the whole
+        # scan set, so the index is built before any file is extracted.
+        index_scanned_types(api_files, directory_path)
         for file in api_files:
             endpoints.extend(find_api_endpoints(Path(file), directory_path))
         log_extraction_drops()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,5 @@ tree-sitter-javascript==0.23.1
 tree-sitter-ruby==0.23.1
 tree-sitter-go==0.25.0
 tree-sitter-typescript==0.23.2
+tree-sitter-java==0.23.5
 requests

--- a/run.sh
+++ b/run.sh
@@ -135,6 +135,7 @@ pip3 install \
   "tree-sitter-ruby==0.23.1" \
   "tree-sitter-go==0.25.0" \
   "tree-sitter-typescript==0.23.2" \
+  "tree-sitter-java==0.23.5" \
   "requests"
 echo "Dependencies installed"
 echo ""

--- a/swagger_generation_cli.py
+++ b/swagger_generation_cli.py
@@ -14,6 +14,7 @@ from nodejs_pipeline.run_swagger_generation import run_swagger_generation as nod
 from python_pipeline.run_swagger_generation import run_swagger_generation as python_swagger_generator
 from rails_pipeline.run_swagger_generation import run_swagger_generation as ruby_on_rails_swagger_generator
 from golang_pipeline.run_swagger_generation import run_swagger_generation as golang_swagger_generator
+from java_pipeline.run_swagger_generation import run_swagger_generation as java_swagger_generator
 from utils import get_output_filepath
 from telemetry_posthog import PostHogTelemetry
 
@@ -49,6 +50,8 @@ class RunSwagger:
                 swagger = ruby_on_rails_swagger_generator(self.user_config['api_host'])
             elif framework == "golang":
                 swagger = golang_swagger_generator(self.user_config['api_host'])
+            elif framework == "spring":
+                swagger = java_swagger_generator(self.user_config['api_host'])
         except Exception as ex:
             traceback.print_exc()
             print("Fallback to old procedure")

--- a/tests/test_java_pipeline_fixes.py
+++ b/tests/test_java_pipeline_fixes.py
@@ -7,6 +7,8 @@ produce a wrong or empty spec, among them:
   bare paths;
 * the verb of a @RequestMapping, which lives in an attribute rather than in the
   annotation's name, and which fans out when several are listed;
+* the mappings an interface declares for the controller that implements it,
+  which is how an API first codebase writes every one of its routes;
 * ignore matching over the relative path, so a repo checked out below /build
   still discovers its .java files;
 * the context hash, which is what keeps an untouched endpoint off the model.
@@ -28,6 +30,7 @@ from java_pipeline.identify_api_functions import (
     find_api_endpoints,
     log_extraction_drops,
     reset_extraction_drops,
+    reset_type_index,
 )
 from java_pipeline.run_swagger_generation import _normalize_swagger_fragment
 
@@ -41,7 +44,21 @@ def _write(path: Path, source: str) -> Path:
 def _endpoints(tmp_path: Path, source: str) -> list:
     java_file = _write(tmp_path / "UserController.java", source)
     reset_extraction_drops()
+    reset_type_index()
     return find_api_endpoints(java_file, str(tmp_path))
+
+
+def _scan_set_endpoints(tmp_path: Path, files: dict) -> list:
+    """Extraction over a whole repo, which is what resolves an implements clause."""
+    repo = tmp_path / "repo"
+    for relative, source in files.items():
+        _write(repo / relative, source)
+    reset_extraction_drops()
+    reset_type_index()
+    endpoints = []
+    for path in find_api_definition_files(str(repo)):
+        endpoints.extend(find_api_endpoints(Path(path), str(repo)))
+    return endpoints
 
 
 def _routes(tmp_path: Path, source: str) -> set:
@@ -301,6 +318,277 @@ public class Outer {
 def test_only_the_annotated_class_contributes_endpoints(tmp_path):
     """A nested controller is a controller; its enclosing class is not."""
     assert _routes(tmp_path, NESTED_CONTROLLER) == {("GET", "/routed")}
+
+
+USER_API_INTERFACE = """package com.acme.api;
+
+@RequestMapping("/api/v1")
+public interface UserApi {
+
+    @GetMapping("/users/{id}")
+    User get(String id);
+
+    @PostMapping("/users")
+    User create(User user);
+}
+"""
+
+UNANNOTATED_IMPLEMENTATION = """package com.acme.web;
+
+import com.acme.api.UserApi;
+
+@RestController
+public class UserController implements UserApi {
+
+    @Override
+    public User get(String id) {
+        return null;
+    }
+
+    @Override
+    public User create(User user) {
+        return user;
+    }
+}
+"""
+
+
+def test_an_interface_declares_the_mappings_its_implementation_serves(tmp_path):
+    """The API first pattern: the contract carries the annotations, the
+    controller carries the body. The endpoints belong to the body."""
+    endpoints = _scan_set_endpoints(
+        tmp_path,
+        {
+            "api/UserApi.java": USER_API_INTERFACE,
+            "web/UserController.java": UNANNOTATED_IMPLEMENTATION,
+        },
+    )
+
+    assert {(item["method"], item["route"]) for item in endpoints} == {
+        ("GET", "/api/v1/users/{id}"),
+        ("POST", "/api/v1/users"),
+    }
+    # Once each, and owned by the implementation: its file, its line span.
+    assert len(endpoints) == 2
+    assert {item["file_path"] for item in endpoints} == {
+        str(tmp_path / "repo" / "web" / "UserController.java")
+    }
+    get = next(item for item in endpoints if item["method"] == "GET")
+    lines = UNANNOTATED_IMPLEMENTATION.splitlines()[
+        get["start_line"] - 1 : get["end_line"]
+    ]
+    assert lines[0].strip() == "@Override"
+    assert lines[-1].strip() == "}"
+
+
+DUPLICATING_IMPLEMENTATION = """package com.acme.web;
+
+import com.acme.api.UserApi;
+
+@RestController
+@RequestMapping("/api/v1")
+public class UserController implements UserApi {
+
+    @Override
+    @GetMapping("/users/{id}")
+    public User get(String id) {
+        return null;
+    }
+
+    @Override
+    @PostMapping("/users")
+    public User create(User user) {
+        return user;
+    }
+}
+"""
+
+
+def test_annotations_repeated_on_the_implementation_are_not_a_second_endpoint(tmp_path):
+    """The interface and the class say the same thing, and the route is served
+    once, so it is documented once."""
+    endpoints = _scan_set_endpoints(
+        tmp_path,
+        {
+            "api/UserApi.java": USER_API_INTERFACE,
+            "web/UserController.java": DUPLICATING_IMPLEMENTATION,
+        },
+    )
+
+    assert len(endpoints) == 2
+    assert {(item["method"], item["route"]) for item in endpoints} == {
+        ("GET", "/api/v1/users/{id}"),
+        ("POST", "/api/v1/users"),
+    }
+
+
+OVERRIDING_IMPLEMENTATION = """package com.acme.web;
+
+import com.acme.api.UserApi;
+
+@RestController
+public class UserController implements UserApi {
+
+    @Override
+    @GetMapping("/people/{id}")
+    public User get(String id) {
+        return null;
+    }
+
+    @Override
+    public User create(User user) {
+        return user;
+    }
+}
+"""
+
+
+def test_the_implementation_mapping_wins_over_the_interface_one(tmp_path):
+    """Spring routes what the bean class declares, and the class prefix still
+    comes from the interface because the class declares none."""
+    endpoints = _scan_set_endpoints(
+        tmp_path,
+        {
+            "api/UserApi.java": USER_API_INTERFACE,
+            "web/UserController.java": OVERRIDING_IMPLEMENTATION,
+        },
+    )
+
+    assert {(item["method"], item["route"]) for item in endpoints} == {
+        ("GET", "/api/v1/people/{id}"),
+        ("POST", "/api/v1/users"),
+    }
+
+
+def test_a_mapped_interface_nobody_implements_emits_nothing(tmp_path, capsys):
+    """There is no body to document, and inventing one from the signature would
+    publish routes no bean serves."""
+    endpoints = _scan_set_endpoints(tmp_path, {"api/UserApi.java": USER_API_INTERFACE})
+
+    assert endpoints == []
+    assert extraction_drops() == {"assumed_get": 0, "unresolved": 2}
+
+    log_extraction_drops()
+    assert "skipped 2 mappings" in capsys.readouterr().out
+
+
+NEGOTIATED_CONTROLLER = """package com.acme.web;
+
+@RestController
+@RequestMapping("/api/v1")
+public class OrderController {
+
+    @PostMapping(value = "/orders", consumes = "application/json")
+    public void createFromJson(@RequestBody Order order) {}
+
+    @PostMapping(value = "/orders", consumes = "application/xml")
+    public void createFromXml(@RequestBody OrderXml order) {}
+}
+"""
+
+
+def test_content_negotiation_variants_become_one_endpoint_carrying_both_bodies(
+    tmp_path, monkeypatch
+):
+    """Two handlers, one operation. Dropping the second used to lose the xml
+    request body entirely, so both bodies are documented together, each under
+    the condition that picks it."""
+    repo = tmp_path / "repo"
+    controller = _write(repo / "web" / "OrderController.java", NEGOTIATED_CONTROLLER)
+    _prepare_run(monkeypatch, repo, tmp_path / "out")
+    reset_extraction_drops()
+    reset_type_index()
+
+    jobs = rsg._dedupe_endpoint_jobs(find_api_endpoints(controller, str(repo)))
+
+    assert len(jobs) == 1
+    _, body = rsg.provide_context_codeblock(str(repo), jobs[0])
+    prompt_body = "".join(body)
+    assert "// Mapping conditions: consumes=application/json" in prompt_body
+    assert "// Mapping conditions: consumes=application/xml" in prompt_body
+    assert "createFromJson" in prompt_body
+    assert "createFromXml" in prompt_body
+
+
+def test_two_handlers_that_differ_by_nothing_stay_one_job():
+    """Nothing tells them apart, so the second is the same endpoint registered
+    twice and costs no second call."""
+    jobs = rsg._dedupe_endpoint_jobs([_job("/orders", "POST"), _job("/orders", "POST")])
+
+    assert len(jobs) == 1
+    assert "variants" not in jobs[0]
+
+
+CLASS_LEVEL_PRODUCES = """package com.acme.web;
+
+@RestController
+@RequestMapping(value = "/api/v1", produces = "application/json")
+public class ReportController {
+
+    @GetMapping("/reports")
+    public String reports() {
+        return "[]";
+    }
+}
+"""
+
+
+def test_class_level_conditions_reach_the_endpoint_and_the_prompt(tmp_path, monkeypatch):
+    """The media type the whole controller answers in is part of the operation,
+    and it is only written once, on the class."""
+    repo = tmp_path / "repo"
+    controller = _write(repo / "web" / "ReportController.java", CLASS_LEVEL_PRODUCES)
+    _prepare_run(monkeypatch, repo, tmp_path / "out")
+    reset_extraction_drops()
+    reset_type_index()
+
+    endpoints = find_api_endpoints(controller, str(repo))
+
+    assert [item.get("conditions") for item in endpoints] == [
+        {"produces": ["application/json"]}
+    ]
+    _, body = rsg.provide_context_codeblock(str(repo), endpoints[0])
+    assert "// Mapping conditions: produces=application/json" in "".join(body)
+
+
+NESTED_DTO = """package com.acme;
+
+public class Dto {
+
+    public static class UserRequest {
+        public String id;
+    }
+}
+"""
+
+NESTED_IMPORT_CONTROLLER = """package com.acme.web;
+
+import com.acme.Dto.UserRequest;
+
+@RestController
+public class NestedController {
+
+    @PostMapping("/users")
+    public void create(@RequestBody UserRequest request) {}
+}
+"""
+
+
+def test_a_nested_type_import_resolves_to_the_file_of_its_outer_type(tmp_path):
+    """com.acme.Dto.UserRequest is declared inside com/acme/Dto.java; there is
+    no Dto/UserRequest.java, and looking for one recorded no edge at all."""
+    repo = tmp_path / "repo"
+    dto = _write(repo / "src/main/java/com/acme/Dto.java", NESTED_DTO)
+    controller = _write(
+        repo / "src/main/java/com/acme/web/NestedController.java",
+        NESTED_IMPORT_CONTROLLER,
+    )
+
+    info = process_file(str(controller), str(repo))
+
+    nested = {item["imported_name"]: item for item in info["imports"]}["UserRequest"]
+    assert nested["origin"] == str(dto)
+    assert nested["path_exists"] is True
 
 
 CONTROLLER_WITH_IMPORTS = """package com.acme.web;

--- a/tests/test_java_pipeline_fixes.py
+++ b/tests/test_java_pipeline_fixes.py
@@ -1,0 +1,858 @@
+"""Regression tests for the java (Spring) pipeline.
+
+Covers the parts of extraction and of the incremental run that would silently
+produce a wrong or empty spec, among them:
+
+* the class level @RequestMapping prefix, without which every controller emits
+  bare paths;
+* the verb of a @RequestMapping, which lives in an attribute rather than in the
+  annotation's name, and which fans out when several are listed;
+* ignore matching over the relative path, so a repo checked out below /build
+  still discovers its .java files;
+* the context hash, which is what keeps an untouched endpoint off the model.
+"""
+
+import json
+import os
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+os.environ["APIMESH_CONFIG_PATH"] = str(REPO_ROOT / "config.yml")
+
+import java_pipeline.definition_swagger_generator as dsg
+import java_pipeline.run_swagger_generation as rsg
+from java_pipeline.find_api_definition_files import find_api_definition_files
+from java_pipeline.generate_file_information import process_file
+from java_pipeline.identify_api_functions import (
+    extraction_drops,
+    find_api_endpoints,
+    log_extraction_drops,
+    reset_extraction_drops,
+)
+from java_pipeline.run_swagger_generation import _normalize_swagger_fragment
+
+
+def _write(path: Path, source: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def _endpoints(tmp_path: Path, source: str) -> list:
+    java_file = _write(tmp_path / "UserController.java", source)
+    reset_extraction_drops()
+    return find_api_endpoints(java_file, str(tmp_path))
+
+
+def _routes(tmp_path: Path, source: str) -> set:
+    return {
+        (endpoint["method"], endpoint["route"])
+        for endpoint in _endpoints(tmp_path, source)
+    }
+
+
+ALL_VERBS = """package com.acme.web;
+
+@RestController
+@RequestMapping("/api/v1")
+public class UserController {
+
+    @GetMapping("/users/{id}")
+    public User get(@PathVariable String id) {
+        return null;
+    }
+
+    @PostMapping("/users")
+    public User create(@RequestBody User user) {
+        return user;
+    }
+
+    @PutMapping("/users/{id}")
+    public void replace() {}
+
+    @DeleteMapping("/users/{id}")
+    public void remove() {}
+
+    @PatchMapping("/users/{id}")
+    public void patch() {}
+}
+"""
+
+
+def test_every_verb_annotation_lands_under_the_class_prefix(tmp_path):
+    assert _routes(tmp_path, ALL_VERBS) == {
+        ("GET", "/api/v1/users/{id}"),
+        ("POST", "/api/v1/users"),
+        ("PUT", "/api/v1/users/{id}"),
+        ("DELETE", "/api/v1/users/{id}"),
+        ("PATCH", "/api/v1/users/{id}"),
+    }
+
+
+REQUEST_MAPPING_VERB = """package com.acme.web;
+
+@Controller
+@RequestMapping(path = "/admin")
+public class AdminController {
+
+    @RequestMapping(value = "/users/{id}", method = RequestMethod.PUT)
+    public void replace() {}
+
+    @RequestMapping(method = RequestMethod.POST)
+    public void createOnThePrefix() {}
+}
+"""
+
+
+def test_request_mapping_reads_its_verb_from_the_method_attribute(tmp_path):
+    """The verb is an attribute here, not part of the annotation's name, and a
+    mapping with no path of its own sits on the class prefix alone."""
+    assert _routes(tmp_path, REQUEST_MAPPING_VERB) == {
+        ("PUT", "/admin/users/{id}"),
+        ("POST", "/admin"),
+    }
+
+
+FAN_OUT = """package com.acme.web;
+
+@RestController
+@RequestMapping({"/api", "/api/v2"})
+public class ItemController {
+
+    @RequestMapping(value = {"/items", "/things"}, method = {RequestMethod.PUT, RequestMethod.PATCH})
+    public void upsert() {}
+}
+"""
+
+
+def test_multi_path_and_multi_method_mappings_fan_out(tmp_path):
+    """Two class prefixes, two paths and two verbs are eight endpoints, and
+    every one of them is a route the service really serves."""
+    assert _routes(tmp_path, FAN_OUT) == {
+        (verb, f"{prefix}{path}")
+        for verb in ("PUT", "PATCH")
+        for prefix in ("/api", "/api/v2")
+        for path in ("/items", "/things")
+    }
+
+
+NO_METHOD_ATTRIBUTE = """package com.acme.web;
+
+@RestController
+public class LegacyController {
+
+    @RequestMapping("/legacy")
+    public void legacy() {}
+}
+"""
+
+
+def test_a_request_mapping_without_a_method_is_documented_as_get_only(tmp_path, capsys):
+    """Spring serves every verb here. Documenting seven operations from one
+    handler invents six of them, so only GET is emitted and the assumption is
+    reported rather than hidden."""
+    assert _routes(tmp_path, NO_METHOD_ATTRIBUTE) == {("GET", "/legacy")}
+    assert extraction_drops() == {"assumed_get": 1, "unresolved": 0}
+
+    log_extraction_drops()
+    assert "documented 1 @RequestMapping methods" in capsys.readouterr().out
+
+
+UNREADABLE_MAPPING = """package com.acme.web;
+
+@RestController
+public class ConstantController {
+
+    @GetMapping(Paths.USERS)
+    public void users() {}
+
+    @GetMapping("/ok")
+    public void ok() {}
+}
+"""
+
+
+def test_a_path_the_parser_cannot_read_is_dropped_not_invented(tmp_path, capsys):
+    """The constant's value is unknowable at parse time; documenting the route
+    as the class prefix alone would publish a path nobody serves."""
+    assert _routes(tmp_path, UNREADABLE_MAPPING) == {("GET", "/ok")}
+    assert extraction_drops() == {"assumed_get": 0, "unresolved": 1}
+
+    log_extraction_drops()
+    assert "skipped 1 mappings" in capsys.readouterr().out
+
+
+NOT_A_CONTROLLER = """package com.acme.service;
+
+@Service
+public class UserService {
+
+    @GetMapping("/users")
+    public User find(String id) {
+        return null;
+    }
+}
+"""
+
+
+def test_a_service_class_defines_no_endpoints(tmp_path):
+    """Nothing routes to a @Service, whatever its methods are annotated with."""
+    assert _routes(tmp_path, NOT_A_CONTROLLER) == set()
+
+
+NO_CLASS_PREFIX = """package com.acme.web;
+
+@RestController
+public class RootController {
+
+    @GetMapping("/health")
+    public String health() {
+        return "ok";
+    }
+
+    @GetMapping
+    public String index() {
+        return "index";
+    }
+}
+"""
+
+
+def test_a_controller_without_a_class_prefix_keeps_the_method_paths(tmp_path):
+    """With no prefix and no path there is nothing left but the root."""
+    assert _routes(tmp_path, NO_CLASS_PREFIX) == {("GET", "/health"), ("GET", "/")}
+
+
+TRAILING_SLASH_PREFIX = """package com.acme.web;
+
+@RestController
+@RequestMapping("/api/v1/")
+public class UserController {
+
+    @GetMapping("/users")
+    public void list() {}
+}
+"""
+
+
+def test_prefix_join_never_doubles_slashes(tmp_path):
+    assert _routes(tmp_path, TRAILING_SLASH_PREFIX) == {("GET", "/api/v1/users")}
+
+
+SPAN_SOURCE = """package com.acme.web;
+
+@RestController
+public class UserController {
+
+    @GetMapping("/users")
+    @ResponseStatus(HttpStatus.OK)
+    public List<User> list(@RequestParam int page) {
+        return List.of();
+    }
+}
+"""
+
+
+def test_the_endpoint_span_covers_the_whole_annotated_method(tmp_path):
+    """The prompt is read off these lines, so the mapping annotation and the
+    parameter annotations have to be inside them."""
+    endpoints = _endpoints(tmp_path, SPAN_SOURCE)
+
+    assert len(endpoints) == 1
+    endpoint = endpoints[0]
+    assert (endpoint["start_line"], endpoint["end_line"]) == (6, 10)
+    assert endpoint["name"] == "list"
+    assert endpoint["file_path"] == str(tmp_path / "UserController.java")
+
+    lines = SPAN_SOURCE.splitlines()[endpoint["start_line"] - 1 : endpoint["end_line"]]
+    assert lines[0].strip() == '@GetMapping("/users")'
+    assert lines[-1].strip() == "}"
+
+
+def test_a_non_ascii_comment_does_not_shift_the_offsets(tmp_path):
+    """tree-sitter reports byte offsets. One three-byte character above the
+    mappings used to push every later str index out of alignment, and the paths
+    were read as garbage."""
+    source = ALL_VERBS.replace(
+        "@RestController",
+        "// Users API, maintained by Renée. See docs/routing.md.\n@RestController",
+    )
+
+    assert _routes(tmp_path, source) == _routes(tmp_path, ALL_VERBS)
+
+
+NESTED_CONTROLLER = """package com.acme.web;
+
+public class Outer {
+
+    @GetMapping("/not-routed")
+    public void ignored() {}
+
+    @RestController
+    public static class Inner {
+
+        @GetMapping("/routed")
+        public void routed() {}
+    }
+}
+"""
+
+
+def test_only_the_annotated_class_contributes_endpoints(tmp_path):
+    """A nested controller is a controller; its enclosing class is not."""
+    assert _routes(tmp_path, NESTED_CONTROLLER) == {("GET", "/routed")}
+
+
+CONTROLLER_WITH_IMPORTS = """package com.acme.web;
+
+import com.acme.model.User;
+import com.acme.service.UserService;
+
+@RestController
+@RequestMapping("/api/v1")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/users/{id}")
+    public User get(@PathVariable String id) {
+        return userService.find(id);
+    }
+}
+"""
+
+USER_SERVICE = """package com.acme.service;
+
+import com.acme.model.User;
+
+public class UserService {
+
+    public User find(String id) {
+        return new User(id);
+    }
+}
+"""
+
+USER_MODEL = """package com.acme.model;
+
+public class User {
+
+    private final String id;
+
+    public User(String id) {
+        this.id = id;
+    }
+}
+"""
+
+
+def _spring_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    source_root = repo / "src" / "main" / "java" / "com" / "acme"
+    _write(source_root / "web" / "UserController.java", CONTROLLER_WITH_IMPORTS)
+    _write(source_root / "service" / "UserService.java", USER_SERVICE)
+    _write(source_root / "model" / "User.java", USER_MODEL)
+    return repo
+
+
+def test_an_import_resolves_to_the_file_of_its_package(tmp_path):
+    """com.acme.service.UserService is the file sitting under com/acme/service,
+    and the simple name is what every usage site writes."""
+    repo = _spring_repo(tmp_path)
+    controller = repo / "src/main/java/com/acme/web/UserController.java"
+
+    info = process_file(str(controller), str(repo))
+
+    by_name = {item["imported_name"]: item for item in info["imports"]}
+    assert set(by_name) == {"User", "UserService"}
+    assert by_name["UserService"]["origin"] == str(
+        repo / "src/main/java/com/acme/service/UserService.java"
+    )
+    assert by_name["UserService"]["path_exists"] is True
+    # The type is named on the field and in the constructor, never inside the
+    # handler, which is why imports are scoped to the file.
+    assert by_name["UserService"]["usage_lines"] == [10, 12]
+
+
+def test_wildcard_imports_record_the_package_they_name(tmp_path):
+    repo = _spring_repo(tmp_path)
+    controller = _write(
+        repo / "src/main/java/com/acme/web/WildcardController.java",
+        """package com.acme.web;
+
+import com.acme.service.*;
+
+@RestController
+public class WildcardController {
+
+    private final UserService userService;
+
+    @GetMapping("/users")
+    public void list() {}
+}
+""",
+    )
+
+    info = process_file(str(controller), str(repo))
+
+    wildcard = info["imports"][0]
+    assert wildcard["imported_name"] == "*"
+    assert wildcard["origin"] == str(repo / "src/main/java/com/acme/service")
+    # The package binds every one of its types, so the usage says which one.
+    assert [usage["name"] for usage in wildcard["usages"]] == ["UserService"]
+
+
+def test_ignored_dirs_are_matched_relative_to_the_repo_root(tmp_path):
+    """"build" above the repo root is not the repo's own build directory."""
+    repo_root = tmp_path / "build" / "myrepo"
+    _write(repo_root / "web" / "UserController.java", ALL_VERBS)
+    _write(repo_root / "target" / "Generated.java", ALL_VERBS)
+    _write(repo_root / "web" / "Plain.java", "package com.acme.web;\n\nclass Plain {}\n")
+
+    found = find_api_definition_files(str(repo_root))
+
+    assert found == [str(repo_root / "web" / "UserController.java")]
+
+
+def test_fragment_is_rekeyed_under_the_extractor_route():
+    """The model's own path and method are discarded."""
+    fragment = {
+        "paths": {
+            "/rewritten/{id}": {
+                "parameters": [],
+                "get": {"summary": "Fetch a user", "responses": {}},
+            }
+        }
+    }
+
+    assert _normalize_swagger_fragment(fragment, "/api/v1/users/{id}", "GET") == {
+        "/api/v1/users/{id}": {"get": {"summary": "Fetch a user", "responses": {}}}
+    }
+
+
+def test_invalid_fragments_are_rejected():
+    assert _normalize_swagger_fragment(None, "/users", "GET") is None
+    assert _normalize_swagger_fragment({}, "/users", "GET") is None
+    assert _normalize_swagger_fragment({"paths": {}}, "/users", "GET") is None
+    assert _normalize_swagger_fragment({"paths": {"/x": {"get": {}}}}, None, "GET") is None
+
+
+def test_batch_selection_keeps_only_the_requested_verb():
+    """One path carries several operations; an endpoint documents exactly one."""
+    payload = {
+        "paths": {
+            "/api/v1/users/{id}": {
+                "get": {"summary": "read"},
+                "delete": {"summary": "remove"},
+            }
+        }
+    }
+
+    assert rsg._operation_from_batch(payload, "/api/v1/users/{id}", "DELETE") == {
+        "/api/v1/users/{id}": {"delete": {"summary": "remove"}}
+    }
+    assert rsg._operation_from_batch(payload, "/api/v1/users/{id}", "PUT") is None
+
+
+def test_batch_renames_legacy_operation_fields():
+    payload = {
+        "paths": {"/users": {"get": {"api_description": "legacy", "module_tag": "Users"}}}
+    }
+
+    assert rsg._operation_from_batch(payload, "/users", "GET") == {
+        "/users": {"get": {"description": "legacy", "x-module-tag": "Users"}}
+    }
+
+
+def test_routes_are_canonical_openapi():
+    """Spring already writes {id}, so only the separators need any work."""
+    assert rsg._normalize_route("/api//v1/users/{id}") == "/api/v1/users/{id}"
+    assert rsg._normalize_route("api/v1") == "/api/v1"
+    assert rsg._normalize_route("") == ""
+    assert rsg._endpoint_key("users/{id}", "get") == "GET /users/{id}"
+
+
+def _job(route, method, file_path="/repo/UserController.java"):
+    return {
+        "route": route,
+        "method": method,
+        "file_path": file_path,
+        "start_line": 1,
+        "end_line": 2,
+    }
+
+
+def _stub_context(monkeypatch, context_blocks=None):
+    monkeypatch.setattr(
+        rsg,
+        "provide_context_codeblock",
+        lambda directory_path, job: (
+            list(context_blocks or []),
+            ["    public void handler() {}\n"],
+        ),
+    )
+
+
+def test_batches_are_grouped_by_file_and_capped_at_ten():
+    jobs = [_job(f"/a/{index}", "GET", "/repo/A.java") for index in range(12)]
+    jobs.append(_job("/b", "POST", "/repo/B.java"))
+
+    batches = rsg._batch_endpoint_jobs(jobs)
+
+    assert [len(batch) for batch in batches] == [10, 2, 1]
+    assert {job["file_path"] for job in batches[0]} == {"/repo/A.java"}
+    assert batches[2][0]["file_path"] == "/repo/B.java"
+
+
+def test_one_batch_call_documents_every_endpoint_of_a_file(monkeypatch):
+    jobs = [_job("/api/v1/users/{id}", "GET"), _job("/api/v1/users", "POST")]
+    calls = []
+    _stub_context(monkeypatch, [["// shared helper\n"]])
+
+    def fake_batch(entries, context_blocks, source_file):
+        calls.append((entries, source_file))
+        return {
+            "paths": {
+                "/api/v1/users/{id}": {"get": {"summary": "read"}},
+                "/api/v1/users": {"post": {"summary": "create"}},
+            }
+        }
+
+    monkeypatch.setattr(rsg, "get_batch_definition_swagger", fake_batch)
+    swagger = {"paths": {}}
+
+    generated, failed = rsg._update_swagger_for_batches(swagger, "/repo", jobs)
+
+    assert len(calls) == 1
+    assert [label for label, _ in calls[0][0]] == [
+        "GET /api/v1/users/{id}",
+        "POST /api/v1/users",
+    ]
+    assert (len(generated), len(failed)) == (2, 0)
+    assert swagger["paths"] == {
+        "/api/v1/users/{id}": {"get": {"summary": "read"}},
+        "/api/v1/users": {"post": {"summary": "create"}},
+    }
+
+
+def test_unusable_batch_reply_falls_back_to_per_endpoint_calls(monkeypatch):
+    jobs = [_job("/users", "GET"), _job("/orders", "POST")]
+    per_endpoint_calls = []
+    _stub_context(monkeypatch)
+    monkeypatch.setattr(
+        rsg, "get_batch_definition_swagger", lambda entries, blocks, source_file: None
+    )
+
+    def fake_single(definition, context, route, http_method=None, source_file=None):
+        per_endpoint_calls.append(route)
+        return {"paths": {"/model/rewrote/this": {http_method.lower(): {"summary": route}}}}
+
+    monkeypatch.setattr(rsg, "get_function_definition_swagger", fake_single)
+    swagger = {"paths": {}}
+
+    generated, failed = rsg._update_swagger_for_batches(swagger, "/repo", jobs)
+
+    assert per_endpoint_calls == ["/users", "/orders"]
+    assert (len(generated), len(failed)) == (2, 0)
+    assert swagger["paths"] == {
+        "/users": {"get": {"summary": "/users"}},
+        "/orders": {"post": {"summary": "/orders"}},
+    }
+
+
+def test_an_endpoint_missing_from_the_batch_reply_fails_alone(monkeypatch, capsys):
+    jobs = [_job("/users", "GET"), _job("/orders", "POST")]
+    _stub_context(monkeypatch)
+    monkeypatch.setattr(
+        rsg,
+        "get_batch_definition_swagger",
+        lambda entries, blocks, source_file: {
+            "paths": {"/orders": {"post": {"summary": "create"}}}
+        },
+    )
+    swagger = {"paths": {}}
+
+    generated, failed = rsg._update_swagger_for_batches(swagger, "/repo", jobs)
+
+    assert [job["route"] for job in failed] == ["/users"]
+    assert [job["route"] for job in generated] == ["/orders"]
+    assert "skipped GET /users" in capsys.readouterr().out
+
+
+def test_the_batch_prompt_names_the_framework():
+    prompt = dsg.build_batch_prompt(
+        [("GET /users", "public void list() {}\n")], [], "/repo/UserController.java"
+    )
+
+    assert "Java Spring source file" in prompt
+    assert "Paths already use OpenAPI {param} templating." in prompt
+
+
+def _prepare_run(monkeypatch, repo: Path, output_dir: Path) -> Path:
+    """The two paths every run reads: the repo scanned and where output lands."""
+    monkeypatch.setenv("APIMESH_USER_REPO_PATH", str(repo))
+    output_filepath = output_dir / "swagger.json"
+    monkeypatch.setenv("APIMESH_OUTPUT_FILEPATH", str(output_filepath))
+    return output_filepath
+
+
+def _echo_batch(entries, blocks, source_file):
+    """One operation per requested label, the way the model answers."""
+    paths = {}
+    for label, _ in entries:
+        method, route = label.split(" ", 1)
+        paths.setdefault(route, {})[method.lower()] = {"summary": label}
+    return {"paths": paths}
+
+
+def test_a_spring_repo_runs_end_to_end(tmp_path, monkeypatch):
+    """The controller has to survive the whole run: file selection, extraction,
+    the metadata of its imports, the batch call, the spec and the index."""
+    repo = _spring_repo(tmp_path)
+    _write(
+        repo / "src/main/java/com/acme/web/UserController.java",
+        CONTROLLER_WITH_IMPORTS.replace(
+            "    @GetMapping",
+            """    @PostMapping("/users")
+    public User create(@RequestBody User user) {
+        return user;
+    }
+
+    @GetMapping""",
+        ),
+    )
+    output_filepath = _prepare_run(monkeypatch, repo, tmp_path / "out")
+    monkeypatch.setattr(rsg, "get_git_commit_hash", lambda: "commit")
+    monkeypatch.setattr(rsg, "get_github_repo_url", lambda: "https://example.com/repo")
+    monkeypatch.setattr(rsg, "get_batch_definition_swagger", _echo_batch)
+
+    swagger = rsg.run_swagger_generation("http://localhost:8080")
+
+    assert set(swagger["paths"]) == {"/api/v1/users", "/api/v1/users/{id}"}
+    assert set(swagger["paths"]["/api/v1/users"]) == {"post"}
+    assert set(swagger["paths"]["/api/v1/users/{id}"]) == {"get"}
+    assert swagger["servers"] == [{"url": "http://localhost:8080"}]
+
+    index = json.loads(
+        (output_filepath.parent / "api_index.json").read_text(encoding="utf-8")
+    )
+    assert set(index) == {"GET /api/v1/users/{id}", "POST /api/v1/users"}
+    entry = index["GET /api/v1/users/{id}"]
+    assert entry["files"][0]["file_path"].endswith("web/UserController.java")
+    imported = {item["file_path"] for item in entry["files"][0]["imports"]}
+    assert str(repo / "src/main/java/com/acme/service/UserService.java") in imported
+    assert entry["context_hash"]
+
+
+PARTIALLY_READABLE_CONTROLLER = """package com.acme.web;
+
+@RestController
+@RequestMapping("/api/v1")
+public class MixedController {
+
+    @GetMapping("/health")
+    public String health() {
+        return "ok";
+    }
+
+    @GetMapping("/users")
+    public String users() {
+        return "users";
+    }
+
+    @GetMapping(Paths.LEGACY)
+    public String legacy() {
+        return "legacy";
+    }
+}
+"""
+
+
+def test_the_coverage_block_sums_the_run(tmp_path, monkeypatch):
+    """Two endpoints extracted, one documented, one the model left out, and one
+    mapping extraction could not read at all."""
+    repo = tmp_path / "repo"
+    _write(repo / "web" / "MixedController.java", PARTIALLY_READABLE_CONTROLLER)
+    _prepare_run(monkeypatch, repo, tmp_path / "out")
+    monkeypatch.setattr(rsg, "get_git_commit_hash", lambda: "commit")
+    monkeypatch.setattr(rsg, "get_github_repo_url", lambda: "https://example.com/repo")
+    monkeypatch.setattr(
+        rsg,
+        "get_batch_definition_swagger",
+        lambda *args, **kwargs: {"paths": {"/api/v1/health": {"get": {"summary": "ok"}}}},
+    )
+
+    swagger = rsg.run_swagger_generation("http://localhost:8080")
+
+    assert swagger["info"]["x-apimesh-coverage"] == {
+        "endpoints_extracted": 2,
+        "generated": 1,
+        "skipped_unchanged": 0,
+        "failed": 1,
+        "dropped_routes": 1,
+    }
+
+
+def test_a_repo_without_endpoints_falls_back(tmp_path, monkeypatch, capsys):
+    repo = tmp_path / "repo"
+    _write(repo / "Main.java", "package com.acme;\n\npublic class Main {}\n")
+    _prepare_run(monkeypatch, repo, tmp_path / "out")
+
+    assert rsg.run_swagger_generation("http://localhost:8080") is None
+    assert (
+        "apimesh: java parser found 0 endpoints, falling back to generic extraction"
+        in capsys.readouterr().out
+    )
+
+
+def _incremental_pass(monkeypatch, repo: Path, out_dir: Path, changed_files):
+    """One incremental pass over the repo as it is on disk right now."""
+    calls = []
+
+    def fake_batch(entries, blocks, source_file):
+        calls.append(sorted(label for label, _ in entries))
+        return _echo_batch(entries, blocks, source_file)
+
+    monkeypatch.setattr(rsg, "get_batch_definition_swagger", fake_batch)
+    monkeypatch.setattr(rsg, "get_git_commit_hash", lambda: "head")
+    monkeypatch.setattr(rsg, "get_github_repo_url", lambda: "https://example.com/repo")
+    monkeypatch.setattr(
+        rsg, "get_changed_files_since", lambda *args, **kwargs: changed_files
+    )
+
+    swagger = rsg.run_swagger_generation("http://localhost:8080")
+
+    # The caller persists the spec between runs, the pipeline reads it back.
+    (out_dir / "swagger.json").write_text(json.dumps(swagger), encoding="utf-8")
+    index = json.loads((out_dir / "api_index.json").read_text(encoding="utf-8"))
+    return swagger, index, calls
+
+
+USERS_CONTROLLER = """package com.acme.web;
+
+import com.acme.service.UserService;
+
+@RestController
+@RequestMapping("/api/v1")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/users/{id}")
+    public String get(@PathVariable String id) {
+        return userService.find(id);
+    }
+
+    @DeleteMapping("/users/{id}")
+    public void remove(@PathVariable String id) {}
+}
+"""
+
+STATUS_CONTROLLER = """package com.acme.web;
+
+@RestController
+public class StatusController {
+
+    @GetMapping("/health")
+    public String health() {
+        return "ok";
+    }
+
+    @GetMapping("/ready")
+    public String ready() {
+        return "ready";
+    }
+}
+"""
+
+
+def test_an_unchanged_endpoint_costs_no_llm_call_and_a_dependency_edit_does(
+    tmp_path, monkeypatch, capsys
+):
+    """Three runs over one checkout. The second regenerates nothing at all, and
+    the third only regenerates the controller that imports the edited service.
+
+    Two endpoints of four is the most that can be dirty without the escalation
+    gate handing the run back for a full regeneration, so the fixture keeps the
+    untouched controller's endpoints out of the dirty set.
+    """
+    repo = tmp_path / "repo"
+    controller = _write(
+        repo / "src/main/java/com/acme/web/UserController.java", USERS_CONTROLLER
+    )
+    _write(repo / "src/main/java/com/acme/web/StatusController.java", STATUS_CONTROLLER)
+    service = _write(
+        repo / "src/main/java/com/acme/service/UserService.java", USER_SERVICE
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    _prepare_run(monkeypatch, repo, out_dir)
+
+    swagger, index, calls = _incremental_pass(monkeypatch, repo, out_dir, set())
+
+    assert set(swagger["paths"]) == {"/api/v1/users/{id}", "/health", "/ready"}
+    # One call per file, so both controllers are documented in two calls.
+    assert len(calls) == 2
+    assert set(index) == {
+        "GET /api/v1/users/{id}",
+        "DELETE /api/v1/users/{id}",
+        "GET /health",
+        "GET /ready",
+    }
+    stored_hash = index["GET /api/v1/users/{id}"]["context_hash"]
+
+    # git reports the controller as touched, but its endpoints read exactly as
+    # they did last run, so neither of them reaches the model.
+    _, index, calls = _incremental_pass(monkeypatch, repo, out_dir, {str(controller)})
+
+    assert calls == []
+    assert index["GET /api/v1/users/{id}"]["context_hash"] == stored_hash
+    assert "skipped 2 unchanged endpoints (context hash match)" in capsys.readouterr().out
+
+    # The imported service changes. Only the controller that imports it is one
+    # hop away, so the status endpoints are never looked at again.
+    service.write_text(
+        USER_SERVICE.replace("return new User(id);", "return new User(id.trim());"),
+        encoding="utf-8",
+    )
+
+    swagger, index, calls = _incremental_pass(monkeypatch, repo, out_dir, {str(service)})
+
+    assert calls == [["DELETE /api/v1/users/{id}", "GET /api/v1/users/{id}"]]
+    assert index["GET /api/v1/users/{id}"]["context_hash"] != stored_hash
+    assert swagger["info"]["x-apimesh-coverage"] == {
+        "endpoints_extracted": 4,
+        "generated": 2,
+        "skipped_unchanged": 2,
+        "failed": 0,
+    }
+
+
+def _cache_dir(out_dir: Path) -> Path:
+    return out_dir / "metadata_cache" / "java"
+
+
+def test_metadata_is_cached_outside_the_scanned_repo(tmp_path, monkeypatch):
+    repo = _spring_repo(tmp_path)
+    out_dir = tmp_path / "out"
+    _prepare_run(monkeypatch, repo, out_dir)
+    monkeypatch.setattr(rsg, "get_git_commit_hash", lambda: "commit")
+    monkeypatch.setattr(rsg, "get_github_repo_url", lambda: "https://example.com/repo")
+    monkeypatch.setattr(rsg, "get_batch_definition_swagger", _echo_batch)
+    before = sorted(path.name for path in repo.iterdir())
+
+    rsg.run_swagger_generation("http://localhost:8080")
+
+    entries = {
+        path.name.rsplit("_", 1)[0] for path in _cache_dir(out_dir).glob("*.json")
+    }
+    assert entries == {"User", "UserController", "UserService"}
+    assert sorted(path.name for path in repo.iterdir()) == before


### PR DESCRIPTION
First-class Java Spring extraction, the first pipeline built on the shared core.

**Extraction (tree-sitter-java):** @RestController/@Controller classes, class-level @RequestMapping prefixes with multi-prefix fan-out, the @GetMapping family and @RequestMapping method= forms with multi-method fan-out, and the API-first pattern: mappings declared on an interface land on the unannotated implementing controller (implementation-owned, emitted once). Handlers sharing route and verb but differing by consumes/produces/params/headers merge into one operation with every variant's body in the prompt. Class-level mapping conditions compose per Spring semantics. Native {param} templating kept verbatim. Unreadable annotations drop their endpoints with a counted log, never a guess.

**Context:** imports resolve deterministically through Java package paths (wildcards, static imports, nested types via longest-existing prefix), file-scoped because Spring DI puts collaborators in fields.

**Inherited from the shared core:** per-file batching under token budgets, hash-skip incremental runs with dependency-hop invalidation, persistent metadata cache, coverage block, per-endpoint failure isolation, success-only indexing.

Suite: 466 tests (37 new incl. an e2e smoke). One full cross-model review round completed (4 findings, all fixed with discriminating tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)