### PR TITLE
Retrospective review fixes: Rails singleton methods, Java interface hierarchies

### DIFF
--- a/java_pipeline/find_api_definition_files.py
+++ b/java_pipeline/find_api_definition_files.py
@@ -23,6 +23,13 @@ _ANNOTATION_PATTERN = re.compile(
     r"@\s*(?:" + "|".join(SPRING_WEB_ANNOTATIONS) + r")\b"
 )
 
+# An interface that only passes a contract along carries no annotation of its
+# own, and a controller reaches the mappings it serves through it. Leaving such
+# a file unparsed broke the chain in the middle and lost every one of them.
+_EXTENDING_INTERFACE_PATTERN = re.compile(
+    r"\binterface\s+\w+\s*(?:<[^>]*>)?\s+extends\b"
+)
+
 
 def _is_ignored(path: Path, base_path: Path) -> bool:
     # Only components below the scanned repo may be ignored, otherwise a repo
@@ -49,7 +56,9 @@ def file_contains_api_defs(file_path: Path) -> bool:
         text = file_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return False
-    return bool(_ANNOTATION_PATTERN.search(text))
+    return bool(
+        _ANNOTATION_PATTERN.search(text) or _EXTENDING_INTERFACE_PATTERN.search(text)
+    )
 
 
 def find_api_definition_files(directory: str) -> List[str]:

--- a/java_pipeline/identify_api_functions.py
+++ b/java_pipeline/identify_api_functions.py
@@ -49,6 +49,15 @@ _CONDITION_ATTRIBUTES = _NEGOTIATION_ATTRIBUTES + _PREDICATE_ATTRIBUTES
 _MODIFIERS = "modifiers"
 _ANNOTATION_TYPES = {"marker_annotation", "annotation"}
 
+# Every declaration that can enclose another one, so a nested interface is named
+# through the types around it rather than as if it sat at the top level.
+_TYPE_DECLARATIONS = {
+    "class_declaration",
+    "interface_declaration",
+    "enum_declaration",
+    "record_declaration",
+}
+
 # Counted across one extraction run and reported once, so a repo that silently
 # loses routes says so instead of shipping a thin spec.
 _EXTRACTION_DROPS = {"assumed_get": 0, "unresolved": 0}
@@ -477,13 +486,12 @@ def _imported_types(root: Node, source: bytes) -> Dict[str, str]:
     return types
 
 
-def _implemented_names(declaration: Node, source: bytes) -> List[str]:
-    """The interfaces an implements clause names, generic arguments stripped."""
-    interfaces = declaration.child_by_field_name("interfaces")
-    if interfaces is None:
+def _type_list_names(container: Optional[Node], source: bytes) -> List[str]:
+    """The type names one implements or extends clause lists, generics stripped."""
+    if container is None:
         return []
     names: List[str] = []
-    for child in interfaces.children:
+    for child in container.children:
         if child.type != "type_list":
             continue
         for entry in child.children:
@@ -492,10 +500,32 @@ def _implemented_names(declaration: Node, source: bytes) -> List[str]:
     return names
 
 
+def _implemented_names(declaration: Node, source: bytes) -> List[str]:
+    """The interfaces an implements clause names."""
+    return _type_list_names(declaration.child_by_field_name("interfaces"), source)
+
+
+def _extended_names(declaration: Node, source: bytes) -> List[str]:
+    """The interfaces an interface's own extends clause names."""
+    for child in declaration.children:
+        if child.type == "extends_interfaces":
+            return _type_list_names(child, source)
+    return []
+
+
 def _interface_entry(
-    declaration: Node, source: bytes, package: str, file_path: Path
+    declaration: Node,
+    source: bytes,
+    package: str,
+    imported: Dict[str, str],
+    file_path: Path,
+    nested_name: str,
 ) -> Optional[Dict]:
-    """One scanned interface's mappings, or None when it declares none."""
+    """One scanned interface's mappings, or None when it carries nothing.
+
+    An interface that only extends others still carries the chain to whatever
+    declares the mappings, so it is indexed as well.
+    """
     class_mapping = _class_mapping(declaration, source)
     methods: Dict[Tuple[str, int], Dict] = {}
     for method in _class_methods(declaration):
@@ -505,16 +535,22 @@ def _interface_entry(
         methods[_method_key(method, source)] = _method_mapping(
             annotation, annotation_name, source
         )
-    if class_mapping is None and not methods:
+    extends = _extended_names(declaration, source)
+    if class_mapping is None and not methods and not extends:
         return None
-    name = _declared_name(declaration, source)
     return {
-        "name": name,
+        "name": _declared_name(declaration, source),
         "package": package,
-        "fqn": f"{package}.{name}" if package else name,
+        # The file's imports, so the interfaces this one extends are resolved
+        # in the scope they were written in rather than the implementation's.
+        "imported": imported,
+        # The enclosing types are part of the name: `Contracts.UserApi` is
+        # com.acme.Contracts.UserApi, and there is no com.acme.UserApi to find.
+        "fqn": f"{package}.{nested_name}" if package else nested_name,
         "file_path": str(file_path),
         "class_mapping": class_mapping,
         "methods": methods,
+        "extends": extends,
         "implemented": False,
     }
 
@@ -529,35 +565,52 @@ def _index_file_types(file_path: str, index: Dict) -> None:
     root = parser.parse(source).root_node
     package = _package_name(root, source)
     imported = _imported_types(root, source)
-    stack = [root]
+    # Each node is walked with the dotted path of the types enclosing it, which
+    # is what a nested interface is named by.
+    stack = [(root, "")]
     while stack:
-        node = stack.pop()
-        if node.type == "interface_declaration":
-            entry = _interface_entry(node, source, package, path)
-            if entry is not None:
-                index["by_fqn"][entry["fqn"]] = entry
-                index["by_simple"].setdefault(entry["name"], []).append(entry)
-        elif node.type == "class_declaration" and _has_controller_annotation(
-            node, source
-        ):
-            index["implements"].append(
-                (package, imported, _implemented_names(node, source))
-            )
-        stack.extend(list(node.children))
+        node, enclosing = stack.pop()
+        inner = enclosing
+        if node.type in _TYPE_DECLARATIONS:
+            name = _declared_name(node, source)
+            inner = f"{enclosing}.{name}" if enclosing else name
+            if node.type == "interface_declaration":
+                entry = _interface_entry(node, source, package, imported, path, inner)
+                if entry is not None:
+                    index["by_fqn"][entry["fqn"]] = entry
+                    index["by_simple"].setdefault(entry["name"], []).append(entry)
+            elif node.type == "class_declaration" and _has_controller_annotation(
+                node, source
+            ):
+                index["implements"].append(
+                    (package, imported, _implemented_names(node, source))
+                )
+        stack.extend((child, inner) for child in node.children)
 
 
 def _resolve_interface(
     name: str, package: str, imported: Dict[str, str], index: Dict
 ) -> Optional[Dict]:
-    """The scanned interface an implements clause names.
+    """The scanned interface an implements or extends clause names.
 
     Resolution reads the package the way import resolution does: a qualified
     name is matched whole, a simple one through the file's imports, then its
     own package, and only then by simple name when the scan set holds exactly
-    one interface with it.
+    one interface with it. A dotted name is also how a nested type is written
+    through its outer one, so its first segment is resolved the same way and
+    the rest of the path is appended to what that gives.
     """
     if "." in name:
-        return index["by_fqn"].get(name)
+        entry = index["by_fqn"].get(name)
+        if entry is not None:
+            return entry
+        head, _, rest = name.partition(".")
+        outer = imported.get(head)
+        if outer:
+            entry = index["by_fqn"].get(f"{outer}.{rest}")
+            if entry is not None:
+                return entry
+        return index["by_fqn"].get(f"{package}.{name}") if package else None
     qualified = imported.get(name)
     if qualified:
         return index["by_fqn"].get(qualified)
@@ -568,20 +621,46 @@ def _resolve_interface(
     return candidates[0] if len(candidates) == 1 else None
 
 
+def _interface_closure(
+    names: Iterable[str], package: str, imported: Dict[str, str], index: Dict
+) -> List[Dict]:
+    """The interfaces these names reach through extends, nearest first.
+
+    Spring's MethodIntrospector searches the parent interfaces too, so the
+    mappings on `V1Api` are served by a controller that only claims the
+    `V2Api extends V1Api` in between. Breadth first, so the nearest declaration
+    of a name is the one that wins, and each interface is walked once, so a
+    diamond or a cycle terminates.
+    """
+    entries: List[Dict] = []
+    visited: set = set()
+    queue = [(name, package, imported) for name in names]
+    while queue:
+        name, from_package, from_imported = queue.pop(0)
+        entry = _resolve_interface(name, from_package, from_imported, index)
+        if entry is None or entry["fqn"] in visited:
+            continue
+        visited.add(entry["fqn"])
+        entries.append(entry)
+        queue.extend(
+            (parent, entry["package"], entry["imported"]) for parent in entry["extends"]
+        )
+    return entries
+
+
 def index_scanned_types(files: Iterable[str], repo_root: str) -> Dict:
     """The mapping interfaces of the scan set, and which of them are implemented.
 
     An interface nobody in the scan set implements has no body to document, so
-    it emits nothing and every mapping it declares is counted as dropped.
+    it emits nothing and every mapping it declares is counted as dropped. An
+    interface reached through an extends chain is implemented all the same.
     """
     index: Dict = {"by_fqn": {}, "by_simple": {}, "implements": []}
     for file_path in files:
         _index_file_types(file_path, index)
     for package, imported, names in index["implements"]:
-        for name in names:
-            entry = _resolve_interface(name, package, imported, index)
-            if entry is not None:
-                entry["implemented"] = True
+        for entry in _interface_closure(names, package, imported, index):
+            entry["implemented"] = True
     for entry in index["by_fqn"].values():
         if not entry["implemented"]:
             _EXTRACTION_DROPS["unresolved"] += len(entry["methods"])
@@ -608,15 +687,15 @@ def _inherited_mappings(
 ) -> Dict:
     """The mappings this controller inherits from the interfaces it implements.
 
-    The first interface that declares a prefix contributes it, and the first
-    that declares a mapping for a method signature contributes that.
+    The nearest interface that declares a prefix contributes it, and the nearest
+    that declares a mapping for a method signature contributes that. The parents
+    of those interfaces are walked too, since Spring reads them as well.
     """
     class_mapping: Optional[Dict] = None
     methods: Dict[Tuple[str, int], Dict] = {}
-    for name in _implemented_names(declaration, source):
-        entry = _resolve_interface(name, package, imported, index)
-        if entry is None:
-            continue
+    for entry in _interface_closure(
+        _implemented_names(declaration, source), package, imported, index
+    ):
         if class_mapping is None:
             class_mapping = entry["class_mapping"]
         for key, mapping in entry["methods"].items():

--- a/java_pipeline/run_swagger_generation.py
+++ b/java_pipeline/run_swagger_generation.py
@@ -617,8 +617,14 @@ def _maybe_incremental_update(
         return pipeline_common.apply_host(existing_swagger, host)
     changed_keys = set()
     for key in existing_keys & new_keys:
+        # A merged variant lives in its own file, and an edit or an addition
+        # there is an edit to this endpoint. Reading only the job that carries
+        # them left a route clean while its operation lost a whole variant.
+        handlers = [
+            variant for job in endpoint_map.get(key) or [] for variant in _job_variants(job)
+        ]
         if pipeline_common.endpoint_has_changed(
-            existing_index.get(key), endpoint_map.get(key), changed_files
+            existing_index.get(key), handlers, changed_files
         ):
             changed_keys.add(key)
 

--- a/rails_pipeline/generate_file_information.py
+++ b/rails_pipeline/generate_file_information.py
@@ -94,6 +94,25 @@ def _gather_module_info(node, source: str) -> Dict:
     }
 
 
+def _is_singleton_method(node) -> bool:
+    """
+    Whether a `def` defines a method on the class itself rather than on its
+    instances. `def self.destroy` is a node type of its own; a plain `def`
+    written inside `class << self` is an ordinary method node that happens to
+    sit in a singleton scope, and only its ancestors say so.
+    """
+    if node.type == "singleton_method":
+        return True
+    parent = node.parent
+    while parent is not None:
+        if parent.type == "singleton_class":
+            return True
+        if parent.type in {"class", "module"} and parent.is_named:
+            return False
+        parent = parent.parent
+    return False
+
+
 def _gather_method_info(node, source: str) -> Dict:
     name_node = node.child_by_field_name("name")
     name = _node_text(source, name_node) if name_node else "<anonymous>"
@@ -102,6 +121,9 @@ def _gather_method_info(node, source: str) -> Dict:
         "name": name,
         "start_line": node.start_point[0] + 1,
         "end_line": node.end_point[0] + 1,
+        # Rails routes to instance methods only, so the kind is what keeps a
+        # class method out of the action maps while the metadata still has it.
+        "kind": "singleton" if _is_singleton_method(node) else "instance",
     }
 
 

--- a/rails_pipeline/identify_api_functions.py
+++ b/rails_pipeline/identify_api_functions.py
@@ -981,11 +981,26 @@ def _ancestor_method_info(
     }
 
 
+def _in_singleton_scope(node: Node) -> bool:
+    """Whether a plain `def` sits inside a `class << self` block."""
+    parent = node.parent
+    while parent is not None:
+        if parent.type == "singleton_class":
+            return True
+        if parent.type in {"class", "module"} and parent.is_named:
+            return False
+        parent = parent.parent
+    return False
+
+
 def _collect_controller_methods(root: Node, source: str, file_path: Path):
     """
     Returns (methods, class_name); the class name is the first class the file
     declares, which is the controller even when the file also holds an inner
     class.
+
+    Only instance methods: Rails routes to those alone, so a `singleton_method`
+    node and a `def` under `class << self` are both left out.
     """
     methods: List[Dict] = []
     class_names: List[tuple] = []
@@ -1003,7 +1018,7 @@ def _collect_controller_methods(root: Node, source: str, file_path: Path):
             cursor.extend(list(node.children))
             continue
 
-        if node.type == "method":
+        if node.type == "method" and not _in_singleton_scope(node):
             name_node = node.child_by_field_name("name")
             if not name_node:
                 continue

--- a/rails_pipeline/run_swagger_generation.py
+++ b/rails_pipeline/run_swagger_generation.py
@@ -1040,6 +1040,10 @@ def _contained_method_map(
     else. Taking every `def` inside the span handed a concern the methods of its
     own nested `module ClassMethods`, and a route named after one of them was
     documented as an action Rails answers 404 on.
+
+    A class method is the same kind of mistake: `def self.destroy` and anything
+    under `class << self` are never actions, so they stay out of the map the
+    ancestry walk resolves a route through.
     """
     method_map: Dict[str, Dict[str, int]] = {}
     if not isinstance(start_line, int) or not isinstance(end_line, int):
@@ -1050,6 +1054,7 @@ def _contained_method_map(
         func_end = func.get("end_line")
         if (
             not method_name
+            or func.get("kind") == "singleton"
             or not isinstance(func_start, int)
             or not isinstance(func_end, int)
             or not start_line <= func_start <= end_line

--- a/tests/test_java_pipeline_fixes.py
+++ b/tests/test_java_pipeline_fixes.py
@@ -460,6 +460,141 @@ def test_the_implementation_mapping_wins_over_the_interface_one(tmp_path):
     }
 
 
+V1_API_INTERFACE = """package com.acme.api;
+
+@RequestMapping("/api/v1")
+public interface V1Api {
+
+    @GetMapping("/users/{id}")
+    User get(String id);
+
+    @PostMapping("/users")
+    User create(User user);
+}
+"""
+
+V2_API_INTERFACE = """package com.acme.api;
+
+public interface V2Api extends V1Api {
+}
+"""
+
+V2_IMPLEMENTATION = """package com.acme.web;
+
+import com.acme.api.V2Api;
+
+@RestController
+public class UserController implements V2Api {
+
+    @Override
+    public User get(String id) {
+        return null;
+    }
+
+    @Override
+    public User create(User user) {
+        return user;
+    }
+}
+"""
+
+
+def test_an_interface_inherits_the_mappings_of_the_one_it_extends(tmp_path):
+    """Spring searches the parent interfaces too, so a controller claiming only
+    V2Api still serves everything V1Api declares."""
+    endpoints = _scan_set_endpoints(
+        tmp_path,
+        {
+            "api/V1Api.java": V1_API_INTERFACE,
+            "api/V2Api.java": V2_API_INTERFACE,
+            "web/UserController.java": V2_IMPLEMENTATION,
+        },
+    )
+
+    assert {(item["method"], item["route"]) for item in endpoints} == {
+        ("GET", "/api/v1/users/{id}"),
+        ("POST", "/api/v1/users"),
+    }
+    assert len(endpoints) == 2
+    assert {item["file_path"] for item in endpoints} == {
+        str(tmp_path / "repo" / "web" / "UserController.java")
+    }
+    # Reached through the chain, so V1Api counts as implemented and nothing is
+    # reported as a mapping that never landed on a body.
+    assert extraction_drops() == {"assumed_get": 0, "unresolved": 0}
+
+
+NESTED_CONTRACTS = """package com.acme.api;
+
+public interface Contracts {
+
+    @RequestMapping("/api/v1")
+    interface UserApi {
+
+        @GetMapping("/users/{id}")
+        User get(String id);
+    }
+
+    @RequestMapping("/api/v1")
+    interface OrderApi {
+
+        @GetMapping("/orders")
+        String list();
+    }
+}
+"""
+
+IMPORTING_NESTED_IMPLEMENTATION = """package com.acme.web;
+
+import com.acme.api.Contracts;
+
+@RestController
+public class UserController implements Contracts.UserApi {
+
+    @Override
+    public User get(String id) {
+        return null;
+    }
+}
+"""
+
+SAME_PACKAGE_NESTED_IMPLEMENTATION = """package com.acme.api;
+
+@RestController
+public class OrderController implements Contracts.OrderApi {
+
+    @Override
+    public String list() {
+        return "[]";
+    }
+}
+"""
+
+
+def test_a_nested_contract_interface_resolves_through_its_outer_type(tmp_path):
+    """`Contracts.UserApi` is com.acme.api.Contracts.UserApi. Indexed as though
+    it sat at the top level, it matched no implements clause and every mapping
+    it declares was thrown away."""
+    endpoints = _scan_set_endpoints(
+        tmp_path,
+        {
+            "api/Contracts.java": NESTED_CONTRACTS,
+            "web/UserController.java": IMPORTING_NESTED_IMPLEMENTATION,
+            "api/OrderController.java": SAME_PACKAGE_NESTED_IMPLEMENTATION,
+        },
+    )
+
+    # Resolved through the import in one file, through the package in the other.
+    assert {
+        (item["method"], item["route"], Path(item["file_path"]).name)
+        for item in endpoints
+    } == {
+        ("GET", "/api/v1/users/{id}", "UserController.java"),
+        ("GET", "/api/v1/orders", "OrderController.java"),
+    }
+    assert extraction_drops() == {"assumed_get": 0, "unresolved": 0}
+
+
 def test_a_mapped_interface_nobody_implements_emits_nothing(tmp_path, capsys):
     """There is no body to document, and inventing one from the signature would
     publish routes no bean serves."""
@@ -997,12 +1132,14 @@ def test_a_repo_without_endpoints_falls_back(tmp_path, monkeypatch, capsys):
     )
 
 
-def _incremental_pass(monkeypatch, repo: Path, out_dir: Path, changed_files):
+def _incremental_pass(monkeypatch, repo: Path, out_dir: Path, changed_files, entries_seen=None):
     """One incremental pass over the repo as it is on disk right now."""
     calls = []
 
     def fake_batch(entries, blocks, source_file):
         calls.append(sorted(label for label, _ in entries))
+        if entries_seen is not None:
+            entries_seen.extend(entries)
         return _echo_batch(entries, blocks, source_file)
 
     monkeypatch.setattr(rsg, "get_batch_definition_swagger", fake_batch)
@@ -1121,6 +1258,82 @@ def test_an_unchanged_endpoint_costs_no_llm_call_and_a_dependency_edit_does(
         "generated": 2,
         "skipped_unchanged": 2,
         "failed": 0,
+    }
+
+
+JSON_ORDERS_CONTROLLER = """package com.acme.web;
+
+@RestController
+@RequestMapping("/api/v1")
+public class OrderController {
+
+    @PostMapping(value = "/orders", consumes = "application/json")
+    public void createFromJson(@RequestBody Order order) {}
+
+    @GetMapping("/orders")
+    public String list() {
+        return "[]";
+    }
+}
+"""
+
+XML_ORDERS_CONTROLLER = """package com.acme.web;
+
+@RestController
+@RequestMapping("/api/v1")
+public class XmlOrderController {
+
+    @PostMapping(value = "/orders", consumes = "application/xml")
+    public void createFromXml(@RequestBody OrderXml order) {}
+}
+"""
+
+
+def test_a_variant_arriving_from_another_file_dirties_the_endpoint(
+    tmp_path, monkeypatch
+):
+    """The xml handler of POST /orders is added in a file the endpoint never
+    mentioned. Only the json handler's file was watched, so the endpoint read as
+    clean and its operation stayed missing the whole xml request body."""
+    repo = tmp_path / "repo"
+    _write(repo / "src/main/java/com/acme/web/OrderController.java", JSON_ORDERS_CONTROLLER)
+    _write(repo / "src/main/java/com/acme/web/StatusController.java", STATUS_CONTROLLER)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    _prepare_run(monkeypatch, repo, out_dir)
+
+    _, index, calls = _incremental_pass(monkeypatch, repo, out_dir, set())
+
+    assert len(calls) == 2
+    assert set(index) == {
+        "POST /api/v1/orders",
+        "GET /api/v1/orders",
+        "GET /health",
+        "GET /ready",
+    }
+    stored_hash = index["POST /api/v1/orders"]["context_hash"]
+
+    xml = _write(
+        repo / "src/main/java/com/acme/web/XmlOrderController.java",
+        XML_ORDERS_CONTROLLER,
+    )
+
+    entries: list = []
+    _, index, calls = _incremental_pass(
+        monkeypatch, repo, out_dir, {str(xml)}, entries_seen=entries
+    )
+
+    assert calls == [["POST /api/v1/orders"]]
+    assert index["POST /api/v1/orders"]["context_hash"] != stored_hash
+    # Both bodies reach the prompt, each under the condition that picks it.
+    body = dict(entries)["POST /api/v1/orders"]
+    assert "// Mapping conditions: consumes=application/json" in body
+    assert "// Mapping conditions: consumes=application/xml" in body
+    assert "createFromJson" in body and "createFromXml" in body
+    # And the xml file is now an edge of its own, so the next edit to it lands.
+    assert {item["file_path"] for item in index["POST /api/v1/orders"]["files"]} == {
+        str(repo / "src/main/java/com/acme/web/OrderController.java"),
+        str(xml),
     }
 
 

--- a/tests/test_rails_pipeline_fixes.py
+++ b/tests/test_rails_pipeline_fixes.py
@@ -2087,6 +2087,118 @@ def test_a_nested_class_methods_module_is_not_an_action(tmp_path, monkeypatch):
     assert dropped == ["GET /signals/purge (signals#purge)"]
 
 
+SINGLETON_CONCERN = """module Destroyable
+  extend ActiveSupport::Concern
+
+  def self.destroy
+    Signal.destroy_all
+  end
+
+  class << self
+    def purge
+      Signal.purge_all
+    end
+  end
+end
+"""
+
+SINGLETON_CONCERN_CONTROLLER = """class SignalsController < ApplicationController
+  include Destroyable
+
+  def index
+    render json: []
+  end
+end
+"""
+
+SINGLETON_ROUTES = """Rails.application.routes.draw do
+  delete '/signals/destroy', to: 'signals#destroy'
+  get '/signals/purge', to: 'signals#purge'
+  resources :signals, only: [:index]
+end
+"""
+
+
+def test_a_class_method_on_a_concern_is_not_an_action(tmp_path, monkeypatch):
+    """`Destroyable.destroy` is a class method, and Rails routes to instance
+    methods, so the route has no body to document and drops."""
+    repo_root = tmp_path / "singleton_app"
+    _write(repo_root / "config" / "routes.rb", SINGLETON_ROUTES)
+    concern = _write(
+        repo_root / "app" / "controllers" / "concerns" / "destroyable.rb",
+        SINGLETON_CONCERN,
+    )
+    controller = _write(
+        repo_root / "app" / "controllers" / "signals_controller.rb",
+        SINGLETON_CONCERN_CONTROLLER,
+    )
+    class_index = _build_class_index(monkeypatch, repo_root, tmp_path / "out")
+
+    assert class_index["Destroyable"]["methods"] == {}
+
+    route_map: dict = {}
+    find_api_endpoints(repo_root / "config" / "routes.rb", str(repo_root), route_map)
+    dropped: list = []
+    endpoints = find_api_endpoints(
+        controller, str(repo_root), route_map, class_index, dropped
+    )
+
+    methods = {method["route"]: method for method in endpoints[0]["methods"]}
+    assert set(methods) == {"/signals"}
+    assert sorted(dropped) == [
+        "DELETE /signals/destroy (signals#destroy)",
+        "GET /signals/purge (signals#purge)",
+    ]
+
+    # Dropped from the action maps, still in the metadata the prompts read.
+    functions = process_file(str(concern), str(repo_root))["elements"]["functions"]
+    assert {item["name"]: item["kind"] for item in functions} == {
+        "destroy": "singleton",
+        "purge": "singleton",
+    }
+
+
+SINGLETON_CONTROLLER = """class SignalsController < ApplicationController
+  def index
+    render json: []
+  end
+
+  class << self
+    def destroy
+      Signal.destroy_all
+    end
+  end
+end
+"""
+
+SINGLETON_CONTROLLER_ROUTES = """Rails.application.routes.draw do
+  delete '/signals/destroy', to: 'signals#destroy'
+  resources :signals, only: [:index]
+end
+"""
+
+
+def test_a_class_method_on_the_controller_itself_is_not_an_action(tmp_path, monkeypatch):
+    """The same rule inside the controller file: `class << self` holds no action."""
+    repo_root = tmp_path / "singleton_controller_app"
+    _write(repo_root / "config" / "routes.rb", SINGLETON_CONTROLLER_ROUTES)
+    controller = _write(
+        repo_root / "app" / "controllers" / "signals_controller.rb", SINGLETON_CONTROLLER
+    )
+    class_index = _build_class_index(monkeypatch, repo_root, tmp_path / "out")
+
+    route_map: dict = {}
+    find_api_endpoints(repo_root / "config" / "routes.rb", str(repo_root), route_map)
+    dropped: list = []
+    endpoints = find_api_endpoints(
+        controller, str(repo_root), route_map, class_index, dropped
+    )
+
+    methods = {method["route"]: method for method in endpoints[0]["methods"]}
+    assert set(methods) == {"/signals"}
+    assert dropped == ["DELETE /signals/destroy (signals#destroy)"]
+
+
 HELPER_CONTROLLER = """class HelperWidgetsController < ApplicationController
   def show
     set_widget


### PR DESCRIPTION
Post-release fixes from the retrospective cross-model review of v2.0.0/v2.1.0.

- Rails: singleton methods (def self.x, class << self) are excluded from controller action resolution, so a concern's class method can no longer be documented as a route's handler.
- Java: interface extends chains resolve recursively per Spring's actual handler introspection; nested interfaces get enclosing-path names so implements Contracts.UserApi resolves; pure interface declaration files join the scan set; a consumes/produces variant added in a second file dirties its endpoint on incremental runs.

471 tests (5 new); every code hunk verified load-bearing by individual revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)