### PR TITLE
chore: generic examples in the design doc and a test name

### DIFF
--- a/docs/contract-lane.md
+++ b/docs/contract-lane.md
@@ -52,14 +52,14 @@ Every potential operation, from any lane, becomes a candidate:
 
 ```json
 {
-  "source_id": "spec:src/main/resources/esd.core/adhoc.yml#get /bootstrap",
+  "source_id": "spec:src/main/resources/specs/orders.yaml#get /api/orders",
   "lane": "contract | code",
   "method": "GET",
-  "route": "/api/bootstrap",
-  "route_shape": "GET /api/bootstrap",
+  "route": "/api/orders",
+  "route_shape": "GET /api/orders",
   "doc_index": 0,
-  "invocations": [{"tier": 2, "build_file": "esd-app/BUILD.bazel", "generator": "spring", "kind": "server"}],
-  "service": "esd-web-app",
+  "invocations": [{"tier": 2, "build_file": "app/BUILD.bazel", "generator": "spring", "kind": "server"}],
+  "service": "orders-service",
   "eligibility_hash": "<spec content + every build file carrying its invocations + implementing controller files + prover version>",
   "payload_hash": "<the operation object plus its resolved reference closure>",
   "operation": {"...": "authored content, refs resolved and namespaced"}

--- a/tests/test_contract_lane_inventory.py
+++ b/tests/test_contract_lane_inventory.py
@@ -338,7 +338,7 @@ def test_loader_reports_missing_pointer_targets(tmp_path):
     assert len(unresolved) == 1
 
 
-def test_loader_handles_the_esd_shaped_fixture():
+def test_loader_handles_the_spring_fixture():
     """The pets fixture loads clean: three operations, ids and tags intact."""
     fixture = FIXTURES_ROOT / "openapi_first_spring"
     entry = _entry_for(fixture, "app/src/main/resources/api/pets.yaml")


### PR DESCRIPTION
Replaces path names borrowed from the validation repository with generic ones in docs/contract-lane.md and one test name. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)